### PR TITLE
Implement function calls

### DIFF
--- a/lib/Language/Bel/Primitives.pm
+++ b/lib/Language/Bel/Primitives.pm
@@ -109,6 +109,18 @@ sub make_prim {
     );
 }
 
+my %prim_fn = (
+    "car" => { fn => \&prim_car, arity => 1 },
+    "cdr" => { fn => \&prim_cdr, arity => 1 },
+    "id" => { fn => \&prim_id, arity => 2 },
+    "join" => { fn => \&prim_join, arity => 2 },
+    "type" => { fn => \&prim_type, arity => 1 },
+);
+
+sub PRIM_FN {
+    return \%prim_fn;
+}
+
 my %primitives = (
     "car" => make_prim("car"),
     "cdr" => make_prim("cdr"),
@@ -127,6 +139,7 @@ our @EXPORT_OK = qw(
     prim_id 
     prim_join
     prim_type
+    PRIM_FN
     PRIMITIVES
 );
 

--- a/t/fncall.t
+++ b/t/fncall.t
@@ -1,0 +1,27 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings;
+use Test::More;
+
+use Language::Bel;
+
+plan tests => 2;
+
+sub is_bel_output {
+    my ($expr, $expected_output) = @_;
+
+    my $actual_output = "";
+    my $b = Language::Bel->new({ output => sub {
+        my ($string) = @_;
+        $actual_output = "$actual_output$string";
+    } });
+    $b->eval($expr);
+
+    is($actual_output, $expected_output, "$expr ==> $expected_output");
+}
+
+{
+    is_bel_output("((lit clo nil (x) (id x nil)) nil)", "t");
+    is_bel_output("((lit clo nil (x) (id x nil)) t)", "nil");
+}


### PR DESCRIPTION
This patch adds a large chunk of the evaluator from bel.bel -- enough to evaluate a function literal like

    (lit clo nil (x) (id x nil))

and also to use it as an operator in a bigger expression, evaluating the arguments and binding the parameters in a lexical environment:

    ((lit clo nil (x) (id x nil)) t)

In this example, parameter binding makes sure to bind `x` to `nil` in the lexical environment that's put on the stack along with the function body:

    (id x nil)

so that when the `x` is evaluated, we get the value `t` back, and the whole expression evaluates to `nil`.

This is a big PR, with 490 additions and 49 deletions. The original Bel source has been interspersed (in comments) with its translation into Perl code. There are many `XXX` comments; things that are in the Bel source but which I didn't need to translate to pass the tests for simple function calls. I will leave them in, but each of them is basically an opportunity for a little PR with some added code, and tests that cover it.

I should probably document the overall architecture of the Bel-P evaluator, which differs from the Bel-B evaluator in `bel.bel`. The major difference is that the latter is highly tail-recursive, but doing the same in Perl would blow past the "deep recursion" warning at level 100 very quickly. Instead of making a recursive call to the top of the evaluator, we instead mutate one of the data structures (usually `$s`/`$expr_stack` or `$r`/`$ret_stack`), and then unroll the stack back out of the top-level `_ev` function, where a `while` loop throws us back in until we're out of expression stack.

Some of the data structures, such as `$expr_stack` and `$ret_stack`, are Perl arrays. They are passed all over the place, and rather than being immutably passed as a different value in the recursive calls, they are unceremoniously mutated just before we unroll the stack. This also means that the `$s` and `$r` parameters we pass to most functions are actually the _same_ references to the expression stack array and the return stack array, respectively. We could keep them in globals, but instead we stick close to the parameter lists of Bel-B.

Other data structures, such as those representing parameter lists and argument lists, are represented as cons lists, that is, Bel pairs all the way down. This is basically decided for us, because both parameters and arguments typically come from inside of the Bel environment itself, where they are already represented like this.

Another thing I want to do is to move the evaluator logic into a separate `Language::Bel::Interpreter`, leaving `Language::Bel` to be quite small, maybe only with a convenience function for creating a throwaway interpreter to evaluate one expression. However, now that I describe this, it strikes me that this might be better done in a separate PR.

Closes #14.