### PR TITLE
Add missing error case for unbound name

### DIFF
--- a/lib/Language/Bel.pm
+++ b/lib/Language/Bel.pm
@@ -290,6 +290,9 @@ sub _vref {
     if (is_pair($it)) {
         push @$r, pair_cdr($it);
     }
+    else {
+        die "('unboundb ", symbol_name($v), ")\n";
+    }
 }
 
 # (def lookup (e a s g)


### PR DESCRIPTION
Without this error, the interpreter would just happily chug along, pushing nothing onto the return stack.

Somewhat later there should really be an overhaul of the error system, including a distinction between the `err` and `sigerr` error messages. See #18.