### PR TITLE
Implement 'scope' variable

### DIFF
--- a/lib/Language/Bel.pm
+++ b/lib/Language/Bel.pm
@@ -333,7 +333,8 @@ sub _lookup {
     # XXX: skipping `binding` case for now
     return $get->($e, $a)
         || $get->($e, $g)
-        # XXX: skipping the `scope globe` defaults for now
+        || (symbol_name($e) eq "scope" && make_pair($e, $a))
+        # XXX: skipping the `globe` default for now
         || SYMBOL_NIL;
 }
 

--- a/t/var-scope.t
+++ b/t/var-scope.t
@@ -1,0 +1,27 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings;
+use Test::More;
+
+use Language::Bel;
+
+plan tests => 2;
+
+sub is_bel_output {
+    my ($expr, $expected_output) = @_;
+
+    my $actual_output = "";
+    my $b = Language::Bel->new({ output => sub {
+        my ($string) = @_;
+        $actual_output = "$actual_output$string";
+    } });
+    $b->eval($expr);
+
+    is($actual_output, $expected_output, "$expr ==> $expected_output");
+}
+
+{
+    is_bel_output("scope", "nil");
+    is_bel_output("((lit clo nil (x) scope) 'a)", "((x . a))");
+}


### PR DESCRIPTION
<del>This PR builds on #32; please merge that one first and rebase this one on top.</del> Rebased.

Building up towards implementing the `fn` macro here; `scope` is a necessary part of that.