### PR TITLE
Implement macro calls

### DIFF
--- a/t/maccall.t
+++ b/t/maccall.t
@@ -1,0 +1,27 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings;
+use Test::More;
+
+use Language::Bel;
+
+plan tests => 2;
+
+sub is_bel_output {
+    my ($expr, $expected_output) = @_;
+
+    my $actual_output = "";
+    my $b = Language::Bel->new({ output => sub {
+        my ($string) = @_;
+        $actual_output = "$actual_output$string";
+    } });
+    $b->eval($expr);
+
+    is($actual_output, $expected_output, "$expr ==> $expected_output");
+}
+
+{
+    is_bel_output("((lit mac (lit clo nil (x) (list 'cons nil x))) 'a)", "(nil . a)");
+    is_bel_output("((lit mac (lit clo nil (x) (list 'cons nil x))) 'b)", "(nil . b)");
+}


### PR DESCRIPTION
A macro call runs through the evaluator twice; first sending the
unexpanded Bel code itself as an argument to the macro, and then
taking the result of that and running it through the evaluator
again.

For example, this Bel code:

    (mac nilwith (x)
      (list 'cons nil x))

Is not representable in our implementation yet because we
don't yet have the `mac` macro.

If we could write it, though, we could run this code:

    (nilwith 'a)

Which would first expand to this code:

    (cons nil 'a)

Which would then evaluate again and give this result:

    (nil . a)

Since we do not yet have `mac`, we instead use a macro literal in
the test:

    ((lit mac (lit clo nil (x)
      (list 'cons nil x)))
      'a)

This ends up being what `(nilwith 'a)` would reduce to after
looking up the `nilwith` macro in the global namespace, so we can
still test that the macro works.