### PR TITLE
Implement (simple) 'fn' macro

### DIFF
--- a/t/mac-fn.t
+++ b/t/mac-fn.t
@@ -1,0 +1,29 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings;
+use Test::More;
+
+use Language::Bel;
+
+plan tests => 4;
+
+sub is_bel_output {
+    my ($expr, $expected_output) = @_;
+
+    my $actual_output = "";
+    my $b = Language::Bel->new({ output => sub {
+        my ($string) = @_;
+        $actual_output = "$actual_output$string";
+    } });
+    $b->eval($expr);
+
+    is($actual_output, $expected_output, "$expr ==> $expected_output");
+}
+
+{
+    is_bel_output("((fn (x) (list x x)) 'a)", "(a a)");
+    is_bel_output("((fn (x y) (list x y)) 'a 'b)", "(a b)");
+    is_bel_output("((fn () (list 'a 'b 'c)))", "(a b c)");
+    is_bel_output("((fn (x) ((fn (y) (list x y)) 'g)) 'f)", "(f g)");
+}


### PR DESCRIPTION
<del>This work builds on top of #36; please merge that PR first and then rebase this one on top.</del> Rebased.

This is not the full `fn` macro; specifically, it doesn't wrap the function in a `do` yet &mdash; we need to implement the `do` macro and then come back and improve this `fn` macro.