### PR TITLE
Improve 'fn' macro

### DIFF
--- a/lib/Language/Bel.pm
+++ b/lib/Language/Bel.pm
@@ -41,11 +41,11 @@ Language::Bel - An interpreter for Paul Graham's language Bel
 
 =head1 VERSION
 
-Version 0.16
+Version 0.17
 
 =cut
 
-our $VERSION = '0.16';
+our $VERSION = '0.17';
 
 =head1 SYNOPSIS
 

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -185,7 +185,9 @@ __DATA__
                           (apply map f (map cdr ls)))))
 
 (mac fn (parms . body)
-  (cons 'list ''lit ''clo 'scope (list 'quote parms) (list 'quote (car body)) nil))
+  (if (no (cdr body))
+    (cons 'list ''lit ''clo 'scope (list 'quote parms) (list 'quote (car body)) nil)
+    (cons 'list ''lit ''clo 'scope (list 'quote parms) (list 'quote (cons 'do body)) nil)))
 
 (set vmark (join))
 

--- a/t/mac-fn.t
+++ b/t/mac-fn.t
@@ -6,7 +6,7 @@ use Test::More;
 
 use Language::Bel;
 
-plan tests => 4;
+plan tests => 6;
 
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
@@ -21,9 +21,24 @@ sub is_bel_output {
     is($actual_output, $expected_output, "$expr ==> $expected_output");
 }
 
+sub is_bel_error {
+    my ($expr, $expected_error) = @_;
+
+    my $b = Language::Bel->new({ output => undef });
+    eval {
+        $b->eval($expr);
+    };
+
+    my $actual_error = $@;
+    $actual_error =~ s/\n$//;
+    is($actual_error, $expected_error, "$expr ==> ERROR[$expected_error]");
+}
+
 {
     is_bel_output("((fn (x) (list x x)) 'a)", "(a a)");
     is_bel_output("((fn (x y) (list x y)) 'a 'b)", "(a b)");
     is_bel_output("((fn () (list 'a 'b 'c)))", "(a b c)");
     is_bel_output("((fn (x) ((fn (y) (list x y)) 'g)) 'f)", "(f g)");
+    is_bel_output("((fn () 'irrelevant 'relevant))", "relevant");
+    is_bel_error("((fn () (car 'atom) 'never))", "car-on-atom");
 }


### PR DESCRIPTION
<del>This work builds on top of #38; please merge that one first, and then rebase this PR.</del> Rebased.

This change adds the case to `fn` where there are several expressions in the body, and the `fn` macro automatically wraps the entire body in a `do` macro.