### PR TITLE
Fix up `fn` with backquotes

### DIFF
--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -191,8 +191,8 @@ __DATA__
 
 (mac fn (parms . body)
   (if (no (cdr body))
-    (cons 'list ''lit ''clo 'scope (list 'quote parms) (list 'quote (car body)) nil)
-    (cons 'list ''lit ''clo 'scope (list 'quote parms) (list 'quote (cons 'do body)) nil)))
+    `(list 'lit 'clo scope ',parms ',(car body))
+    `(list 'lit 'clo scope ',parms '(do ,@body))))
 
 (set vmark (join))
 


### PR DESCRIPTION
<del>This work builds on #40; please merge that PR first and then rebase this one.</del> Rebased.

Since we have quasiquoting now from the start of the globals, we don't have to downlevel the quasiquotes in the `fn` macro.

This brings us to complete parity with bel.bel's definition of `fn`.
