### PR TITLE
Improve 'set' a little bit

### DIFF
--- a/lib/Language/Bel/Interpreter.pm
+++ b/lib/Language/Bel/Interpreter.pm
@@ -807,7 +807,9 @@ __DATA__
   `(list 'lit 'mac (fn ,@args)))
 
 (mac set (v e)
-  `(xdr globe (cons (cons ',v ,e) (cdr globe))))
+  `(do
+     (xdr globe (cons (cons ',v ,e) (cdr globe)))
+     t))
 
 (def err args)
 


### PR DESCRIPTION
<del>Builds on #44, please merge that one and rebase this one on top.</del> Rebased.

Make `set` always return `t`. That's not spec, but it leads to a better experience in the REPL.