### PR TITLE
Implement bracket syntax in reader

### DIFF
--- a/lib/Language/Bel.pm
+++ b/lib/Language/Bel.pm
@@ -77,10 +77,9 @@ sub new {
         ref($options_ref) eq "HASH" ? %$options_ref : (),
     };
 
-    my $interpreter = defined $self->{interpreter}
-        ? $self->{interpreter}
-        : Language::Bel::Interpreter->new();
-    $self->{interpreter} = $interpreter;
+    if (!defined $self->{interpreter}) {
+        $self->{interpreter} = Language::Bel::Interpreter->new();
+    }
 
     return bless($self, $class);
 }

--- a/t/brackets.t
+++ b/t/brackets.t
@@ -1,0 +1,29 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings;
+use Test::More;
+
+use Language::Bel;
+
+plan tests => 4;
+
+sub is_bel_output {
+    my ($expr, $expected_output) = @_;
+
+    my $actual_output = "";
+    my $b = Language::Bel->new({ output => sub {
+        my ($string) = @_;
+        $actual_output = "$actual_output$string";
+    } });
+    $b->eval($expr);
+
+    is($actual_output, $expected_output, "$expr ==> $expected_output");
+}
+
+{
+    is_bel_output("(atom [id _ t])", "nil");
+    is_bel_output("([id _ 'd] 'd)", "t");
+    is_bel_output("(map [car _] '((a b) (c d) (e f)))", "(a c e)");
+    is_bel_output("([] t)", "nil");
+}


### PR DESCRIPTION
<del>Builds on #46; please merge that one and rebase this one on top.</del> Rebased.

The brackets syntax is implemented in order to be able to add the next global definition, namely `=`.