### PR TITLE
Think of another `apply` test

### DIFF
--- a/t/form-apply.t
+++ b/t/form-apply.t
@@ -6,7 +6,7 @@ use Test::More;
 
 use Language::Bel;
 
-plan tests => 6;
+plan tests => 7;
 
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
@@ -28,4 +28,5 @@ sub is_bel_output {
     is_bel_output("(apply no '(t))", "nil");
     is_bel_output("(apply cons '(a b c (d e f)))", "(a b c d e f)");
     is_bel_output("(apply cons '())", "nil");
+    is_bel_output("(map apply (list (fn () 'x) (fn () 'y))", "(x y)");
 }


### PR DESCRIPTION
`apply` is "a third of a special form". Usually, special forms have three properties:

1. The don't let evaluation of their arguments happen left-to-right, but in some other way. Not all arguments necessarily evaluate at all.
2. They have to be in "first position", at the head of the s-expression list, or they're not special.
3. They are handled specially by the evaluator.

Out of these, `apply` only has property 3. As to property 1, apply is almost boringly function-like, and the only reason it can't be purely a function is that it needs access to the `applyf` function in the parent environment.

As to property 2, I think the main reason it _isn't_ a special form is so that it can be passed as a first-class value. That's what the new test is about.