### PR TITLE
Implement `dyn` form

### DIFF
--- a/lib/Language/Bel/Interpreter/Smark.pm
+++ b/lib/Language/Bel/Interpreter/Smark.pm
@@ -1,0 +1,46 @@
+package Language::Bel::Interpreter::Smark;
+
+use 5.006;
+use strict;
+use warnings;
+
+use Exporter 'import';
+
+sub new {
+    my ($class, $type, $value) = @_;
+
+    my $obj = { type => $type, value => $value };
+    return bless($obj, $class);
+}
+
+sub value {
+    my ($self) = @_;
+
+    return $self->{value};
+}
+
+sub is_smark {
+    my ($value) = @_;
+
+    return ref($value) eq "Language::Bel::Interpreter::Smark";
+}
+
+sub is_smark_of_type {
+    my ($value, $type) = @_;
+
+    return is_smark($value) && $value->{type} eq $type;
+}
+
+sub make_smark_of_type {
+    my ($type, $value) = @_;
+
+    return Language::Bel::Interpreter::Smark->new($type, $value);
+}
+
+our @EXPORT_OK = qw(
+    is_smark
+    is_smark_of_type
+    make_smark_of_type
+);
+
+1;

--- a/t/form-dyn.t
+++ b/t/form-dyn.t
@@ -1,0 +1,44 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings;
+use Test::More;
+
+use Language::Bel;
+
+plan tests => 6;
+
+sub is_bel_output {
+    my ($expr, $expected_output) = @_;
+
+    my $actual_output = "";
+    my $b = Language::Bel->new({ output => sub {
+        my ($string) = @_;
+        $actual_output = "$actual_output$string";
+    } });
+    $b->eval($expr);
+
+    is($actual_output, $expected_output, "$expr ==> $expected_output");
+}
+
+sub is_bel_error {
+    my ($expr, $expected_error) = @_;
+
+    my $b = Language::Bel->new({ output => undef });
+    eval {
+        $b->eval($expr);
+    };
+
+    my $actual_error = $@;
+    $actual_error =~ s/\n$//;
+    is($actual_error, $expected_error, "$expr ==> ERROR[$expected_error]");
+}
+
+{
+    is_bel_error("(let f (fn () d) (f))", "('unboundb d)");
+    is_bel_output("(let f (fn () d) (dyn d 'hai (f)))", "hai");
+    is_bel_output("(dyn d 'yes d)", "yes");
+    is_bel_output("(dyn d 'one (cons (dyn d 'two d) d))", "(two . one)");
+    is_bel_output("(let v 'lexical (dyn v 'dynamic v))", "dynamic");
+    is_bel_output("(dyn v 'dynamic (let v 'lexical v))", "dynamic");
+}


### PR DESCRIPTION
Dynamic variables are looked up on the expression stack; their bindings are transparent and automatically dropped when the evaluator gets to them.

Dynamic variables trump lexical variables, which trump global variables.