### PR TITLE
Instantiate the Bel interpreter once per test file, not once per test

### DIFF
--- a/t/axioms.t
+++ b/t/axioms.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 31;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");
@@ -24,7 +26,6 @@ sub is_bel_output {
 sub is_bel_error {
     my ($expr, $expected_error) = @_;
 
-    my $b = Language::Bel->new({ output => undef });
     eval {
         $b->eval($expr);
     };

--- a/t/bquote.t
+++ b/t/bquote.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 15;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");
@@ -24,7 +26,6 @@ sub is_bel_output {
 sub is_bel_error {
     my ($expr, $expected_error) = @_;
 
-    my $b = Language::Bel->new({ output => undef });
     eval {
         $b->eval($expr);
     };

--- a/t/brackets.t
+++ b/t/brackets.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 4;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-all.t
+++ b/t/fn-all.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 4;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-append.t
+++ b/t/fn-append.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 3;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-atom.t
+++ b/t/fn-atom.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 4;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-begins.t
+++ b/t/fn-begins.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 12;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-caddr.t
+++ b/t/fn-caddr.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 4;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-cadr.t
+++ b/t/fn-cadr.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 4;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-cand.t
+++ b/t/fn-cand.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 5;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-caris.t
+++ b/t/fn-caris.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 6;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-cddr.t
+++ b/t/fn-cddr.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 4;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-char.t
+++ b/t/fn-char.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 5;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-combine.t
+++ b/t/fn-combine.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 10;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-compose.t
+++ b/t/fn-compose.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 5;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-con.t
+++ b/t/fn-con.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 4;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-cons.t
+++ b/t/fn-cons.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 5;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-cor.t
+++ b/t/fn-cor.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 5;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-eq.t
+++ b/t/fn-eq.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 10;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-find.t
+++ b/t/fn-find.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 6;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-foldl.t
+++ b/t/fn-foldl.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 5;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-foldr.t
+++ b/t/fn-foldr.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 5;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-function.t
+++ b/t/fn-function.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 8;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-fuse.t
+++ b/t/fn-fuse.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 5;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");
@@ -24,7 +26,6 @@ sub is_bel_output {
 sub is_bel_error {
     my ($expr, $expected_error) = @_;
 
-    my $b = Language::Bel->new({ output => undef });
     eval {
         $b->eval($expr);
     };

--- a/t/fn-get.t
+++ b/t/fn-get.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 3;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-hug.t
+++ b/t/fn-hug.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 4;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-idfn.t
+++ b/t/fn-idfn.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 4;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-in.t
+++ b/t/fn-in.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 3;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-is.t
+++ b/t/fn-is.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 6;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-isa.t
+++ b/t/fn-isa.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 8;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-keep.t
+++ b/t/fn-keep.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 4;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-list.t
+++ b/t/fn-list.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 3;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-map.t
+++ b/t/fn-map.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 4;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-match.t
+++ b/t/fn-match.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 10;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-mem.t
+++ b/t/fn-mem.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 3;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-no.t
+++ b/t/fn-no.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 10;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-of.t
+++ b/t/fn-of.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 5;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-pair.t
+++ b/t/fn-pair.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 5;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-pairwise.t
+++ b/t/fn-pairwise.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 7;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-proper.t
+++ b/t/fn-proper.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 3;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-put.t
+++ b/t/fn-put.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 5;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-reduce.t
+++ b/t/fn-reduce.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 4;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-rem.t
+++ b/t/fn-rem.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 4;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-rev.t
+++ b/t/fn-rev.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 3;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-snap.t
+++ b/t/fn-snap.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 4;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-snoc.t
+++ b/t/fn-snoc.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 3;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-some.t
+++ b/t/fn-some.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 6;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-string.t
+++ b/t/fn-string.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 5;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-symbol.t
+++ b/t/fn-symbol.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 5;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-udrop.t
+++ b/t/fn-udrop.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 4;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-upon.t
+++ b/t/fn-upon.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 3;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fn-uvar.t
+++ b/t/fn-uvar.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 6;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/fncall.t
+++ b/t/fncall.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 2;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/form-apply.t
+++ b/t/form-apply.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 7;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/form-dyn.t
+++ b/t/form-dyn.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 6;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");
@@ -24,7 +26,6 @@ sub is_bel_output {
 sub is_bel_error {
     my ($expr, $expected_error) = @_;
 
-    my $b = Language::Bel->new({ output => undef });
     eval {
         $b->eval($expr);
     };

--- a/t/form-if.t
+++ b/t/form-if.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 5;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/mac-aif.t
+++ b/t/mac-aif.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 3;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/mac-and.t
+++ b/t/mac-and.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 5;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/mac-case.t
+++ b/t/mac-case.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 10;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/mac-def.t
+++ b/t/mac-def.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 2;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/mac-do.t
+++ b/t/mac-do.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 3;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/mac-fn.t
+++ b/t/mac-fn.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 6;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");
@@ -24,7 +26,6 @@ sub is_bel_output {
 sub is_bel_error {
     my ($expr, $expected_error) = @_;
 
-    my $b = Language::Bel->new({ output => undef });
     eval {
         $b->eval($expr);
     };

--- a/t/mac-iflet.t
+++ b/t/mac-iflet.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 3;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/mac-let.t
+++ b/t/mac-let.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 3;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/mac-letu.t
+++ b/t/mac-letu.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 6;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/mac-mac.t
+++ b/t/mac-mac.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 2;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/mac-macro.t
+++ b/t/mac-macro.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 3;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/mac-or.t
+++ b/t/mac-or.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 5;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/mac-pcase.t
+++ b/t/mac-pcase.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 7;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/mac-set.t
+++ b/t/mac-set.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 2;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/mac-with.t
+++ b/t/mac-with.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 2;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/maccall.t
+++ b/t/maccall.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 2;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/malformed.t
+++ b/t/malformed.t
@@ -8,10 +8,11 @@ use Language::Bel;
 
 plan tests => 3;
 
+my $b = Language::Bel->new({ output => undef });
+
 sub is_bel_error {
     my ($expr, $expected_error) = @_;
 
-    my $b = Language::Bel->new({ output => undef });
     eval {
         $b->eval($expr);
     };

--- a/t/optional.t
+++ b/t/optional.t
@@ -9,14 +9,16 @@ use Language::Bel;
 
 plan tests => 20;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/string.t
+++ b/t/string.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 9;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");

--- a/t/var-scope.t
+++ b/t/var-scope.t
@@ -8,14 +8,16 @@ use Language::Bel;
 
 plan tests => 2;
 
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
 sub is_bel_output {
     my ($expr, $expected_output) = @_;
 
-    my $actual_output = "";
-    my $b = Language::Bel->new({ output => sub {
-        my ($string) = @_;
-        $actual_output = "$actual_output$string";
-    } });
+    $actual_output = "";
     $b->eval($expr);
 
     is($actual_output, $expected_output, "$expr ==> $expected_output");


### PR DESCRIPTION
_This work builds on #73; please merge that PR first, and then rebase this one._

This speeds up the test suite by about 142 seconds. (About 17%.)

```
$ boxplot 851 852 813 882 885 857 866 812 800 815
min: 800.00
1qt: 813.50
med: 851.50
3qt: 863.75
max: 885.00
```

```
$ boxplot 716 689 757 730 766 764 703 690 698 677
min: 677.00
1qt: 692.00
med: 709.50
3qt: 750.25
max: 766.00
```

Since we also know that we eliminated exactly 345 interpreter startups, we can get a fairly accurate measure of the interpreter startup time: 0.42 seconds. I think we can do better there.