### PR TITLE
Support intra-word ':' and '~' in reader

### DIFF
--- a/lib/Language/Bel.pm
+++ b/lib/Language/Bel.pm
@@ -47,11 +47,11 @@ Language::Bel - An interpreter for Paul Graham's language Bel
 
 =head1 VERSION
 
-Version 0.21
+Version 0.22
 
 =cut
 
-our $VERSION = '0.21';
+our $VERSION = '0.22';
 
 =head1 SYNOPSIS
 

--- a/t/reader-intrasymbol.t
+++ b/t/reader-intrasymbol.t
@@ -1,0 +1,35 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings;
+use Test::More;
+
+use Language::Bel;
+
+plan tests => 8;
+
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
+sub is_bel_output {
+    my ($expr, $expected_output) = @_;
+
+    $actual_output = "";
+    $b->eval($expr);
+
+    is($actual_output, $expected_output, "$expr ==> $expected_output");
+}
+
+{
+    is_bel_output("'a:b:c", "(compose a b c)");
+    is_bel_output("'~n", "(compose no n)");
+    is_bel_output("'a:~b:c", "(compose a (compose no b) c)");
+    is_bel_output("'~=", "(compose no =)");
+    is_bel_output("'~~z", "(compose no (compose no z))");
+    is_bel_output("'~<", "(compose no <)");
+    is_bel_output("'~", "no");
+    is_bel_output("'~~", "(compose no no)");
+}


### PR DESCRIPTION
This is because the next few globals are going to require them.