### PR TITLE
Add test coverage for optional parameters

### DIFF
--- a/t/fn-get.t
+++ b/t/fn-get.t
@@ -6,7 +6,7 @@ use Test::More;
 
 use Language::Bel;
 
-plan tests => 3;
+plan tests => 6;
 
 my $actual_output = "";
 my $b = Language::Bel->new({ output => sub {
@@ -27,4 +27,7 @@ sub is_bel_output {
     is_bel_output("(let l '((a . 1) (b . 2) (c . 3)) (get 'b l))", "(b . 2)");
     is_bel_output("(let l '((a . 1) (b . 2) (c . 3)) (get 'd l))", "nil");
     is_bel_output("(let l nil (get 'x l))", "nil");
+    is_bel_output("(let l '(((a) . 1) ((b) . 2) ((c) . 3)) (get '(b) l))", "((b) . 2)");
+    is_bel_output("(let l '(((a) . 1) ((b) . 2) ((c) . 3)) (get '(b) l id))", "nil");
+    is_bel_output("(let q '(b) (let l (list '((a) . 1) (cons q 'two) '((c) . 3)) (get q l id))", "((b) . two)");
 }

--- a/t/fn-mem.t
+++ b/t/fn-mem.t
@@ -6,7 +6,7 @@ use Test::More;
 
 use Language::Bel;
 
-plan tests => 3;
+plan tests => 7;
 
 my $actual_output = "";
 my $b = Language::Bel->new({ output => sub {
@@ -27,4 +27,8 @@ sub is_bel_output {
     is_bel_output("(mem 'b '(a b c))", "(b c)");
     is_bel_output("(mem 'e '(a b c))", "nil");
     is_bel_output(q[(mem \\a "foobar")], q["ar"]);
+    is_bel_output("(mem '(x) '((a) b x))", "nil");
+    is_bel_output("(mem '(x) '((a) b (x)))", "((x))");
+    is_bel_output("(mem '(x) '((a) b (x)) id)", "nil");
+    is_bel_output("(let q '(x) (mem q (list '(a) 'b q)))", "((x))");
 }

--- a/t/fn-rem.t
+++ b/t/fn-rem.t
@@ -6,7 +6,7 @@ use Test::More;
 
 use Language::Bel;
 
-plan tests => 4;
+plan tests => 6;
 
 my $actual_output = "";
 my $b = Language::Bel->new({ output => sub {
@@ -25,7 +25,9 @@ sub is_bel_output {
 
 {
     is_bel_output(q[(rem \\a "abracadabra")], q["brcdbr"]);
-    is_bel_output(q[(rem 'b '(a b c b a b))], "(a c a)");
-    is_bel_output(q[(rem 'b '(a c a))], "(a c a)");
-    is_bel_output(q[(rem 'x nil)], "nil");
+    is_bel_output("(rem 'b '(a b c b a b))", "(a c a)");
+    is_bel_output("(rem 'b '(a c a))", "(a c a)");
+    is_bel_output("(rem 'x nil)", "nil");
+    is_bel_output("(rem '() '(a () c () a ()))", "(a c a)");
+    is_bel_output("(rem '(z) '(a (z) c) id)", "(a (z) c)");
 }

--- a/t/fn-snap.t
+++ b/t/fn-snap.t
@@ -6,7 +6,7 @@ use Test::More;
 
 use Language::Bel;
 
-plan tests => 4;
+plan tests => 5;
 
 my $actual_output = "";
 my $b = Language::Bel->new({ output => sub {
@@ -28,4 +28,5 @@ sub is_bel_output {
     is_bel_output("(snap nil '(a b c))", "(nil (a b c))");
     is_bel_output("(snap '(x) '(a b c))", "((a) (b c))");
     is_bel_output("(snap '(x y z w) '(a b c))", "((a b c nil) nil)");
+    is_bel_output("(snap '(x) '(a b c) '(d e))", "((d e a) (b c))");
 }

--- a/t/fn-split.t
+++ b/t/fn-split.t
@@ -6,7 +6,7 @@ use Test::More;
 
 use Language::Bel;
 
-plan tests => 3;
+plan tests => 4;
 
 my $actual_output = "";
 my $b = Language::Bel->new({ output => sub {
@@ -27,4 +27,5 @@ sub is_bel_output {
     is_bel_output(q[(split (is \\a) "frantic")], q[("fr" "antic")]);
     is_bel_output("(split no '(a b nil))", "((a b) (nil))");
     is_bel_output("(split no '(a b c))", "((a b c) nil)");
+    is_bel_output(q[(split (is \\i) "frantic" "quo")], q[("quofrant" "ic")]);
 }


### PR DESCRIPTION
Closes #92.

Coverage for passing values to the optional parameters will turn out to be extra important once we start experimenting with providing fast Perl functions instead of the Bel variants.

These global functions, it turns out, needed test coverage for their optional parameters:

* `mem`
* `rem`
* `get`
* `snap`
* `split`

These, happily, already had such tests:

* `begins`
* `caris`
* `hug`
* `put`