### PR TITLE
Implement fast Perl versions of global Bel functions

### DIFF
--- a/lib/Language/Bel.pm
+++ b/lib/Language/Bel.pm
@@ -54,7 +54,7 @@ Version 0.24
 
 =cut
 
-our $VERSION = '0.24';
+our $VERSION = '0.25';
 
 =head1 SYNOPSIS
 

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -737,38 +737,42 @@ $globals{"keep"} =
     FASTFUNCS->{'keep'});
 
 $globals{"rem"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("x"),
-    make_pair(make_symbol("ys"), make_pair(make_pair(make_symbol("o"),
-    make_pair(make_symbol("f"), make_pair(make_symbol("="), SYMBOL_NIL))),
-    SYMBOL_NIL))), make_pair(make_pair(make_symbol("keep"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("x"), make_pair(make_symbol("ys"),
+    make_pair(make_pair(make_symbol("o"), make_pair(make_symbol("f"),
+    make_pair(make_symbol("="), SYMBOL_NIL))), SYMBOL_NIL))),
+    make_pair(make_pair(make_symbol("keep"),
     make_pair(make_pair(make_symbol("fn"),
     make_pair(make_pair(make_symbol("_"), SYMBOL_NIL),
     make_pair(make_pair(make_symbol("no"),
     make_pair(make_pair(make_symbol("f"), make_pair(make_symbol("_"),
     make_pair(make_symbol("x"), SYMBOL_NIL))), SYMBOL_NIL)), SYMBOL_NIL))),
-    make_pair(make_symbol("ys"), SYMBOL_NIL))), SYMBOL_NIL)))));
+    make_pair(make_symbol("ys"), SYMBOL_NIL))), SYMBOL_NIL))))),
+    FASTFUNCS->{'rem'});
 
 $globals{"get"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("k"),
-    make_pair(make_symbol("kvs"), make_pair(make_pair(make_symbol("o"),
-    make_pair(make_symbol("f"), make_pair(make_symbol("="), SYMBOL_NIL))),
-    SYMBOL_NIL))), make_pair(make_pair(make_symbol("find"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("k"), make_pair(make_symbol("kvs"),
+    make_pair(make_pair(make_symbol("o"), make_pair(make_symbol("f"),
+    make_pair(make_symbol("="), SYMBOL_NIL))), SYMBOL_NIL))),
+    make_pair(make_pair(make_symbol("find"),
     make_pair(make_pair(make_symbol("fn"),
     make_pair(make_pair(make_symbol("_"), SYMBOL_NIL),
     make_pair(make_pair(make_symbol("f"),
     make_pair(make_pair(make_symbol("car"), make_pair(make_symbol("_"),
     SYMBOL_NIL)), make_pair(make_symbol("k"), SYMBOL_NIL))), SYMBOL_NIL))),
-    make_pair(make_symbol("kvs"), SYMBOL_NIL))), SYMBOL_NIL)))));
+    make_pair(make_symbol("kvs"), SYMBOL_NIL))), SYMBOL_NIL))))),
+    FASTFUNCS->{'get'});
 
 $globals{"put"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("k"),
-    make_pair(make_symbol("v"), make_pair(make_symbol("kvs"),
-    make_pair(make_pair(make_symbol("o"), make_pair(make_symbol("f"),
-    make_pair(make_symbol("="), SYMBOL_NIL))), SYMBOL_NIL)))),
-    make_pair(make_pair(make_symbol("cons"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("k"), make_pair(make_symbol("v"),
+    make_pair(make_symbol("kvs"), make_pair(make_pair(make_symbol("o"),
+    make_pair(make_symbol("f"), make_pair(make_symbol("="), SYMBOL_NIL))),
+    SYMBOL_NIL)))), make_pair(make_pair(make_symbol("cons"),
     make_pair(make_pair(make_symbol("cons"), make_pair(make_symbol("k"),
     make_pair(make_symbol("v"), SYMBOL_NIL))),
     make_pair(make_pair(make_symbol("rem"), make_pair(make_symbol("k"),
@@ -777,12 +781,13 @@ $globals{"put"} =
     SYMBOL_NIL)), make_pair(make_pair(make_symbol("f"),
     make_pair(make_pair(make_symbol("car"), make_pair(make_symbol("x"),
     SYMBOL_NIL)), make_pair(make_symbol("y"), SYMBOL_NIL))), SYMBOL_NIL))),
-    SYMBOL_NIL)))), SYMBOL_NIL))), SYMBOL_NIL)))));
+    SYMBOL_NIL)))), SYMBOL_NIL))), SYMBOL_NIL))))), FASTFUNCS->{'put'});
 
 $globals{"rev"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("xs"),
-    SYMBOL_NIL), make_pair(make_pair(make_symbol("if"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("xs"), SYMBOL_NIL),
+    make_pair(make_pair(make_symbol("if"),
     make_pair(make_pair(make_symbol("no"), make_pair(make_symbol("xs"),
     SYMBOL_NIL)), make_pair(SYMBOL_NIL,
     make_pair(make_pair(make_symbol("snoc"),
@@ -790,14 +795,14 @@ $globals{"rev"} =
     make_pair(make_pair(make_symbol("cdr"), make_pair(make_symbol("xs"),
     SYMBOL_NIL)), SYMBOL_NIL)), make_pair(make_pair(make_symbol("car"),
     make_pair(make_symbol("xs"), SYMBOL_NIL)), SYMBOL_NIL))),
-    SYMBOL_NIL)))), SYMBOL_NIL)))));
+    SYMBOL_NIL)))), SYMBOL_NIL))))), FASTFUNCS->{'rev'});
 
 $globals{"snap"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("xs"),
-    make_pair(make_symbol("ys"), make_pair(make_pair(make_symbol("o"),
-    make_pair(make_symbol("acc"), SYMBOL_NIL)), SYMBOL_NIL))),
-    make_pair(make_pair(make_symbol("if"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("xs"), make_pair(make_symbol("ys"),
+    make_pair(make_pair(make_symbol("o"), make_pair(make_symbol("acc"),
+    SYMBOL_NIL)), SYMBOL_NIL))), make_pair(make_pair(make_symbol("if"),
     make_pair(make_pair(make_symbol("no"), make_pair(make_symbol("xs"),
     SYMBOL_NIL)), make_pair(make_pair(make_symbol("list"),
     make_pair(make_symbol("acc"), make_pair(make_symbol("ys"),
@@ -808,21 +813,22 @@ $globals{"snap"} =
     make_pair(make_pair(make_symbol("snoc"), make_pair(make_symbol("acc"),
     make_pair(make_pair(make_symbol("car"), make_pair(make_symbol("ys"),
     SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL)))), SYMBOL_NIL)))),
-    SYMBOL_NIL)))));
+    SYMBOL_NIL))))), FASTFUNCS->{'snap'});
 
 $globals{"udrop"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("xs"),
-    make_pair(make_symbol("ys"), SYMBOL_NIL)),
-    make_pair(make_pair(make_symbol("cadr"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("xs"), make_pair(make_symbol("ys"),
+    SYMBOL_NIL)), make_pair(make_pair(make_symbol("cadr"),
     make_pair(make_pair(make_symbol("snap"), make_pair(make_symbol("xs"),
     make_pair(make_symbol("ys"), SYMBOL_NIL))), SYMBOL_NIL)),
-    SYMBOL_NIL)))));
+    SYMBOL_NIL))))), FASTFUNCS->{'udrop'});
 
 $globals{"idfn"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
-    make_pair(make_symbol("x"), SYMBOL_NIL)))));
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
+    make_pair(make_symbol("x"), SYMBOL_NIL))))), FASTFUNCS->{'idfn'});
 
 $globals{"is"} =
     make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -1065,10 +1065,10 @@ $globals{"upon"} =
     SYMBOL_NIL)))));
 
 $globals{"pairwise"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("f"),
-    make_pair(make_symbol("xs"), SYMBOL_NIL)),
-    make_pair(make_pair(make_symbol("or"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("f"), make_pair(make_symbol("xs"),
+    SYMBOL_NIL)), make_pair(make_pair(make_symbol("or"),
     make_pair(make_pair(make_symbol("no"),
     make_pair(make_pair(make_symbol("cdr"), make_pair(make_symbol("xs"),
     SYMBOL_NIL)), SYMBOL_NIL)), make_pair(make_pair(make_symbol("and"),
@@ -1079,7 +1079,7 @@ $globals{"pairwise"} =
     make_pair(make_pair(make_symbol("pairwise"), make_pair(make_symbol("f"),
     make_pair(make_pair(make_symbol("cdr"), make_pair(make_symbol("xs"),
     SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL))), SYMBOL_NIL))),
-    SYMBOL_NIL)))));
+    SYMBOL_NIL))))), FASTFUNCS->{'pairwise'});
 
 $globals{"fuse"} =
     make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -7,6 +7,7 @@ use warnings;
 use Language::Bel::Types qw(
     make_pair
     make_symbol
+    make_fastfunc
 );
 use Language::Bel::Symbols::Common qw(
     SYMBOL_CHAR
@@ -18,6 +19,9 @@ use Language::Bel::Symbols::Common qw(
 );
 use Language::Bel::Primitives qw(
     PRIMITIVES
+);
+use Language::Bel::Globals::FastFuncs qw(
+    FASTFUNCS
 );
 
 use Exporter 'import';
@@ -41,10 +45,11 @@ $globals{"type"} = PRIMITIVES->{"type"};
 $globals{"xdr"} = PRIMITIVES->{"xdr"};
 
 $globals{"no"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
     make_pair(make_pair(make_symbol("id"), make_pair(make_symbol("x"),
-    make_pair(SYMBOL_NIL, SYMBOL_NIL))), SYMBOL_NIL)))));
+    make_pair(SYMBOL_NIL, SYMBOL_NIL))), SYMBOL_NIL))))), FASTFUNCS->{'no'});
 
 $globals{"atom"} =
     make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -718,10 +718,10 @@ $globals{"with"} =
     SYMBOL_NIL)));
 
 $globals{"keep"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("f"),
-    make_pair(make_symbol("xs"), SYMBOL_NIL)),
-    make_pair(make_pair(make_symbol("if"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("f"), make_pair(make_symbol("xs"),
+    SYMBOL_NIL)), make_pair(make_pair(make_symbol("if"),
     make_pair(make_pair(make_symbol("no"), make_pair(make_symbol("xs"),
     SYMBOL_NIL)), make_pair(SYMBOL_NIL,
     make_pair(make_pair(make_symbol("f"),
@@ -733,7 +733,8 @@ $globals{"keep"} =
     make_pair(make_symbol("xs"), SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL))),
     make_pair(make_pair(make_symbol("keep"), make_pair(make_symbol("f"),
     make_pair(make_pair(make_symbol("cdr"), make_pair(make_symbol("xs"),
-    SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL)))))), SYMBOL_NIL)))));
+    SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL)))))), SYMBOL_NIL))))),
+    FASTFUNCS->{'keep'});
 
 $globals{"rem"} =
     make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -1186,11 +1186,11 @@ $globals{"match"} =
     SYMBOL_NIL))), SYMBOL_NIL)))))))), SYMBOL_NIL)))));
 
 $globals{"split"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("f"),
-    make_pair(make_symbol("xs"), make_pair(make_pair(make_symbol("o"),
-    make_pair(make_symbol("acc"), SYMBOL_NIL)), SYMBOL_NIL))),
-    make_pair(make_pair(make_symbol("if"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("f"), make_pair(make_symbol("xs"),
+    make_pair(make_pair(make_symbol("o"), make_pair(make_symbol("acc"),
+    SYMBOL_NIL)), SYMBOL_NIL))), make_pair(make_pair(make_symbol("if"),
     make_pair(make_pair(make_pair(make_symbol("cor"),
     make_pair(make_symbol("atom"),
     make_pair(make_pair(make_symbol("compose"), make_pair(make_symbol("f"),
@@ -1203,7 +1203,7 @@ $globals{"split"} =
     SYMBOL_NIL)), make_pair(make_pair(make_symbol("snoc"),
     make_pair(make_symbol("acc"), make_pair(make_pair(make_symbol("car"),
     make_pair(make_symbol("xs"), SYMBOL_NIL)), SYMBOL_NIL))),
-    SYMBOL_NIL)))), SYMBOL_NIL)))), SYMBOL_NIL)))));
+    SYMBOL_NIL)))), SYMBOL_NIL)))), SYMBOL_NIL))))), FASTFUNCS->{'split'});
 
 $globals{"when"} =
     make_pair(make_symbol("lit"), make_pair(make_symbol("mac"),

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -1159,10 +1159,10 @@ $globals{"pcase"} =
     SYMBOL_NIL)))), SYMBOL_NIL))))), SYMBOL_NIL)));
 
 $globals{"match"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("x"),
-    make_pair(make_symbol("pat"), SYMBOL_NIL)),
-    make_pair(make_pair(make_symbol("if"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("x"), make_pair(make_symbol("pat"),
+    SYMBOL_NIL)), make_pair(make_pair(make_symbol("if"),
     make_pair(make_pair(make_symbol("="), make_pair(make_symbol("pat"),
     make_pair(SYMBOL_T, SYMBOL_NIL))), make_pair(SYMBOL_T,
     make_pair(make_pair(make_symbol("function"),
@@ -1183,7 +1183,8 @@ $globals{"match"} =
     make_pair(make_pair(make_symbol("cdr"), make_pair(make_symbol("x"),
     SYMBOL_NIL)), make_pair(make_pair(make_symbol("cdr"),
     make_pair(make_symbol("pat"), SYMBOL_NIL)), SYMBOL_NIL))),
-    SYMBOL_NIL))), SYMBOL_NIL)))))))), SYMBOL_NIL)))));
+    SYMBOL_NIL))), SYMBOL_NIL)))))))), SYMBOL_NIL))))),
+    FASTFUNCS->{'match'});
 
 $globals{"split"} =
     make_fastfunc(make_pair(make_symbol("lit"),

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -639,11 +639,12 @@ $globals{"find"} =
     SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL))))), FASTFUNCS->{'find'});
 
 $globals{"begins"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("xs"),
-    make_pair(make_symbol("pat"), make_pair(make_pair(make_symbol("o"),
-    make_pair(make_symbol("f"), make_pair(make_symbol("="), SYMBOL_NIL))),
-    SYMBOL_NIL))), make_pair(make_pair(make_symbol("if"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("xs"), make_pair(make_symbol("pat"),
+    make_pair(make_pair(make_symbol("o"), make_pair(make_symbol("f"),
+    make_pair(make_symbol("="), SYMBOL_NIL))), SYMBOL_NIL))),
+    make_pair(make_pair(make_symbol("if"),
     make_pair(make_pair(make_symbol("no"), make_pair(make_symbol("pat"),
     SYMBOL_NIL)), make_pair(SYMBOL_T,
     make_pair(make_pair(make_symbol("atom"), make_pair(make_symbol("xs"),
@@ -657,17 +658,18 @@ $globals{"begins"} =
     SYMBOL_NIL)), make_pair(make_pair(make_symbol("cdr"),
     make_pair(make_symbol("pat"), SYMBOL_NIL)), make_pair(make_symbol("f"),
     SYMBOL_NIL)))), make_pair(SYMBOL_NIL, SYMBOL_NIL)))))))),
-    SYMBOL_NIL)))));
+    SYMBOL_NIL))))), FASTFUNCS->{'begins'});
 
 $globals{"caris"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("x"),
-    make_pair(make_symbol("y"), make_pair(make_pair(make_symbol("o"),
-    make_pair(make_symbol("f"), make_pair(make_symbol("="), SYMBOL_NIL))),
-    SYMBOL_NIL))), make_pair(make_pair(make_symbol("begins"),
-    make_pair(make_symbol("x"), make_pair(make_pair(make_symbol("list"),
-    make_pair(make_symbol("y"), SYMBOL_NIL)), make_pair(make_symbol("f"),
-    SYMBOL_NIL)))), SYMBOL_NIL)))));
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("x"), make_pair(make_symbol("y"),
+    make_pair(make_pair(make_symbol("o"), make_pair(make_symbol("f"),
+    make_pair(make_symbol("="), SYMBOL_NIL))), SYMBOL_NIL))),
+    make_pair(make_pair(make_symbol("begins"), make_pair(make_symbol("x"),
+    make_pair(make_pair(make_symbol("list"), make_pair(make_symbol("y"),
+    SYMBOL_NIL)), make_pair(make_symbol("f"), SYMBOL_NIL)))),
+    SYMBOL_NIL))))), FASTFUNCS->{'caris'});
 
 $globals{"hug"} =
     make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -1004,10 +1004,10 @@ $globals{"cor"} =
     SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL))), SYMBOL_NIL)))));
 
 $globals{"foldl"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("f"),
-    make_pair(make_symbol("base"), make_symbol("args"))),
-    make_pair(make_pair(make_symbol("if"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("f"), make_pair(make_symbol("base"),
+    make_symbol("args"))), make_pair(make_pair(make_symbol("if"),
     make_pair(make_pair(make_symbol("or"),
     make_pair(make_pair(make_symbol("no"), make_pair(make_symbol("args"),
     SYMBOL_NIL)), make_pair(make_pair(make_symbol("some"),
@@ -1022,13 +1022,13 @@ $globals{"foldl"} =
     make_pair(make_symbol("base"), SYMBOL_NIL))), SYMBOL_NIL))),
     make_pair(make_pair(make_symbol("map"), make_pair(make_symbol("cdr"),
     make_pair(make_symbol("args"), SYMBOL_NIL))), SYMBOL_NIL))))),
-    SYMBOL_NIL)))), SYMBOL_NIL)))));
+    SYMBOL_NIL)))), SYMBOL_NIL))))), FASTFUNCS->{'foldl'});
 
 $globals{"foldr"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("f"),
-    make_pair(make_symbol("base"), make_symbol("args"))),
-    make_pair(make_pair(make_symbol("if"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("f"), make_pair(make_symbol("base"),
+    make_symbol("args"))), make_pair(make_pair(make_symbol("if"),
     make_pair(make_pair(make_symbol("or"),
     make_pair(make_pair(make_symbol("no"), make_pair(make_symbol("args"),
     SYMBOL_NIL)), make_pair(make_pair(make_symbol("some"),
@@ -1043,7 +1043,7 @@ $globals{"foldr"} =
     make_pair(make_symbol("base"), make_pair(make_pair(make_symbol("map"),
     make_pair(make_symbol("cdr"), make_pair(make_symbol("args"),
     SYMBOL_NIL))), SYMBOL_NIL))))), SYMBOL_NIL))), SYMBOL_NIL))),
-    SYMBOL_NIL)))), SYMBOL_NIL)))));
+    SYMBOL_NIL)))), SYMBOL_NIL))))), FASTFUNCS->{'foldr'});
 
 $globals{"of"} =
     make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -52,32 +52,35 @@ $globals{"no"} =
     make_pair(SYMBOL_NIL, SYMBOL_NIL))), SYMBOL_NIL))))), FASTFUNCS->{'no'});
 
 $globals{"atom"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
     make_pair(make_pair(make_symbol("no"),
     make_pair(make_pair(make_symbol("id"),
     make_pair(make_pair(make_symbol("type"), make_pair(make_symbol("x"),
     SYMBOL_NIL)), make_pair(make_pair(SYMBOL_QUOTE, make_pair(SYMBOL_PAIR,
-    SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL)), SYMBOL_NIL)))));
+    SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL)), SYMBOL_NIL))))),
+    FASTFUNCS->{'atom'});
 
 $globals{"all"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("f"),
-    make_pair(make_symbol("xs"), SYMBOL_NIL)),
-    make_pair(make_pair(make_symbol("if"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("f"), make_pair(make_symbol("xs"),
+    SYMBOL_NIL)), make_pair(make_pair(make_symbol("if"),
     make_pair(make_pair(make_symbol("no"), make_pair(make_symbol("xs"),
     SYMBOL_NIL)), make_pair(SYMBOL_T, make_pair(make_pair(make_symbol("f"),
     make_pair(make_pair(make_symbol("car"), make_pair(make_symbol("xs"),
     SYMBOL_NIL)), SYMBOL_NIL)), make_pair(make_pair(make_symbol("all"),
     make_pair(make_symbol("f"), make_pair(make_pair(make_symbol("cdr"),
     make_pair(make_symbol("xs"), SYMBOL_NIL)), SYMBOL_NIL))),
-    make_pair(SYMBOL_NIL, SYMBOL_NIL)))))), SYMBOL_NIL)))));
+    make_pair(SYMBOL_NIL, SYMBOL_NIL)))))), SYMBOL_NIL))))),
+    FASTFUNCS->{'all'});
 
 $globals{"some"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("f"),
-    make_pair(make_symbol("xs"), SYMBOL_NIL)),
-    make_pair(make_pair(make_symbol("if"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("f"), make_pair(make_symbol("xs"),
+    SYMBOL_NIL)), make_pair(make_pair(make_symbol("if"),
     make_pair(make_pair(make_symbol("no"), make_pair(make_symbol("xs"),
     SYMBOL_NIL)), make_pair(SYMBOL_NIL,
     make_pair(make_pair(make_symbol("f"),
@@ -85,13 +88,14 @@ $globals{"some"} =
     SYMBOL_NIL)), SYMBOL_NIL)), make_pair(make_symbol("xs"),
     make_pair(make_pair(make_symbol("some"), make_pair(make_symbol("f"),
     make_pair(make_pair(make_symbol("cdr"), make_pair(make_symbol("xs"),
-    SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL)))))), SYMBOL_NIL)))));
+    SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL)))))), SYMBOL_NIL))))),
+    FASTFUNCS->{'some'});
 
 $globals{"reduce"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("f"),
-    make_pair(make_symbol("xs"), SYMBOL_NIL)),
-    make_pair(make_pair(make_symbol("if"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("f"), make_pair(make_symbol("xs"),
+    SYMBOL_NIL)), make_pair(make_pair(make_symbol("if"),
     make_pair(make_pair(make_symbol("no"),
     make_pair(make_pair(make_symbol("cdr"), make_pair(make_symbol("xs"),
     SYMBOL_NIL)), SYMBOL_NIL)), make_pair(make_pair(make_symbol("car"),
@@ -101,19 +105,20 @@ $globals{"reduce"} =
     SYMBOL_NIL)), make_pair(make_pair(make_symbol("reduce"),
     make_pair(make_symbol("f"), make_pair(make_pair(make_symbol("cdr"),
     make_pair(make_symbol("xs"), SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL))),
-    SYMBOL_NIL)))), SYMBOL_NIL)))));
+    SYMBOL_NIL)))), SYMBOL_NIL))))), FASTFUNCS->{'reduce'});
 
 $globals{"cons"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_symbol("args"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_symbol("args"),
     make_pair(make_pair(make_symbol("reduce"),
     make_pair(make_symbol("join"), make_pair(make_symbol("args"),
-    SYMBOL_NIL))), SYMBOL_NIL)))));
+    SYMBOL_NIL))), SYMBOL_NIL))))), FASTFUNCS->{'cons'});
 
 $globals{"append"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_symbol("args"),
-    make_pair(make_pair(make_symbol("if"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_symbol("args"), make_pair(make_pair(make_symbol("if"),
     make_pair(make_pair(make_symbol("no"),
     make_pair(make_pair(make_symbol("cdr"), make_pair(make_symbol("args"),
     SYMBOL_NIL)), SYMBOL_NIL)), make_pair(make_pair(make_symbol("car"),
@@ -131,28 +136,31 @@ $globals{"append"} =
     make_pair(make_pair(make_symbol("car"), make_pair(make_symbol("args"),
     SYMBOL_NIL)), SYMBOL_NIL)), make_pair(make_pair(make_symbol("cdr"),
     make_pair(make_symbol("args"), SYMBOL_NIL)), SYMBOL_NIL)))),
-    SYMBOL_NIL))), SYMBOL_NIL)))))), SYMBOL_NIL)))));
+    SYMBOL_NIL))), SYMBOL_NIL)))))), SYMBOL_NIL))))), FASTFUNCS->{'append'});
 
 $globals{"snoc"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_symbol("args"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_symbol("args"),
     make_pair(make_pair(make_symbol("append"),
     make_pair(make_pair(make_symbol("car"), make_pair(make_symbol("args"),
     SYMBOL_NIL)), make_pair(make_pair(make_symbol("cdr"),
     make_pair(make_symbol("args"), SYMBOL_NIL)), SYMBOL_NIL))),
-    SYMBOL_NIL)))));
+    SYMBOL_NIL))))), FASTFUNCS->{'snoc'});
 
 $globals{"list"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_symbol("args"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_symbol("args"),
     make_pair(make_pair(make_symbol("append"),
     make_pair(make_symbol("args"), make_pair(SYMBOL_NIL, SYMBOL_NIL))),
-    SYMBOL_NIL)))));
+    SYMBOL_NIL))))), FASTFUNCS->{'list'});
 
 $globals{"map"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("f"),
-    make_symbol("ls")), make_pair(make_pair(make_symbol("if"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("f"), make_symbol("ls")),
+    make_pair(make_pair(make_symbol("if"),
     make_pair(make_pair(make_symbol("no"), make_pair(make_symbol("ls"),
     SYMBOL_NIL)), make_pair(SYMBOL_NIL,
     make_pair(make_pair(make_symbol("some"), make_pair(make_symbol("no"),
@@ -176,7 +184,7 @@ $globals{"map"} =
     make_pair(make_symbol("f"), make_pair(make_pair(make_symbol("map"),
     make_pair(make_symbol("cdr"), make_pair(make_symbol("ls"),
     SYMBOL_NIL))), SYMBOL_NIL)))), SYMBOL_NIL))), SYMBOL_NIL)))))))),
-    SYMBOL_NIL)))));
+    SYMBOL_NIL))))), FASTFUNCS->{'map'});
 
 $globals{"fn"} =
     make_pair(make_symbol("lit"), make_pair(make_symbol("mac"),
@@ -405,9 +413,9 @@ $globals{"and"} =
     SYMBOL_NIL))))), SYMBOL_NIL)));
 
 $globals{"="} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_symbol("args"),
-    make_pair(make_pair(make_symbol("if"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_symbol("args"), make_pair(make_pair(make_symbol("if"),
     make_pair(make_pair(make_symbol("no"),
     make_pair(make_pair(make_symbol("cdr"), make_pair(make_symbol("args"),
     SYMBOL_NIL)), SYMBOL_NIL)), make_pair(SYMBOL_T,
@@ -427,35 +435,39 @@ $globals{"="} =
     make_pair(make_pair(make_symbol("apply"), make_pair(make_symbol("="),
     make_pair(make_pair(make_symbol("map"), make_pair(make_symbol("cdr"),
     make_pair(make_symbol("args"), SYMBOL_NIL))), SYMBOL_NIL))),
-    SYMBOL_NIL))), SYMBOL_NIL)))))), SYMBOL_NIL)))));
+    SYMBOL_NIL))), SYMBOL_NIL)))))), SYMBOL_NIL))))), FASTFUNCS->{'='});
 
 $globals{"symbol"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
     make_pair(make_pair(make_symbol("="),
     make_pair(make_pair(make_symbol("type"), make_pair(make_symbol("x"),
     SYMBOL_NIL)), make_pair(make_pair(SYMBOL_QUOTE, make_pair(SYMBOL_SYMBOL,
-    SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL)))));
+    SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL))))), FASTFUNCS->{'symbol'});
 
 $globals{"pair"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
     make_pair(make_pair(make_symbol("="),
     make_pair(make_pair(make_symbol("type"), make_pair(make_symbol("x"),
     SYMBOL_NIL)), make_pair(make_pair(SYMBOL_QUOTE, make_pair(SYMBOL_PAIR,
-    SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL)))));
+    SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL))))), FASTFUNCS->{'pair'});
 
 $globals{"char"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
     make_pair(make_pair(make_symbol("="),
     make_pair(make_pair(make_symbol("type"), make_pair(make_symbol("x"),
     SYMBOL_NIL)), make_pair(make_pair(SYMBOL_QUOTE, make_pair(SYMBOL_CHAR,
-    SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL)))));
+    SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL))))), FASTFUNCS->{'char'});
 
 $globals{"proper"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
     make_pair(make_pair(make_symbol("or"),
     make_pair(make_pair(make_symbol("no"), make_pair(make_symbol("x"),
     SYMBOL_NIL)), make_pair(make_pair(make_symbol("and"),
@@ -463,56 +475,63 @@ $globals{"proper"} =
     SYMBOL_NIL)), make_pair(make_pair(make_symbol("proper"),
     make_pair(make_pair(make_symbol("cdr"), make_pair(make_symbol("x"),
     SYMBOL_NIL)), SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL))),
-    SYMBOL_NIL)))));
+    SYMBOL_NIL))))), FASTFUNCS->{'proper'});
 
 $globals{"string"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
     make_pair(make_pair(make_symbol("and"),
     make_pair(make_pair(make_symbol("proper"), make_pair(make_symbol("x"),
     SYMBOL_NIL)), make_pair(make_pair(make_symbol("all"),
     make_pair(SYMBOL_CHAR, make_pair(make_symbol("x"), SYMBOL_NIL))),
-    SYMBOL_NIL))), SYMBOL_NIL)))));
+    SYMBOL_NIL))), SYMBOL_NIL))))), FASTFUNCS->{'string'});
 
 $globals{"mem"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("x"),
-    make_pair(make_symbol("ys"), make_pair(make_pair(make_symbol("o"),
-    make_pair(make_symbol("f"), make_pair(make_symbol("="), SYMBOL_NIL))),
-    SYMBOL_NIL))), make_pair(make_pair(make_symbol("some"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("x"), make_pair(make_symbol("ys"),
+    make_pair(make_pair(make_symbol("o"), make_pair(make_symbol("f"),
+    make_pair(make_symbol("="), SYMBOL_NIL))), SYMBOL_NIL))),
+    make_pair(make_pair(make_symbol("some"),
     make_pair(make_pair(make_symbol("fn"),
     make_pair(make_pair(make_symbol("_"), SYMBOL_NIL),
     make_pair(make_pair(make_symbol("f"), make_pair(make_symbol("_"),
     make_pair(make_symbol("x"), SYMBOL_NIL))), SYMBOL_NIL))),
-    make_pair(make_symbol("ys"), SYMBOL_NIL))), SYMBOL_NIL)))));
+    make_pair(make_symbol("ys"), SYMBOL_NIL))), SYMBOL_NIL))))),
+    FASTFUNCS->{'mem'});
 
 $globals{"in"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("x"),
-    make_symbol("ys")), make_pair(make_pair(make_symbol("mem"),
-    make_pair(make_symbol("x"), make_pair(make_symbol("ys"), SYMBOL_NIL))),
-    SYMBOL_NIL)))));
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("x"), make_symbol("ys")),
+    make_pair(make_pair(make_symbol("mem"), make_pair(make_symbol("x"),
+    make_pair(make_symbol("ys"), SYMBOL_NIL))), SYMBOL_NIL))))),
+    FASTFUNCS->{'in'});
 
 $globals{"cadr"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
     make_pair(make_pair(make_symbol("car"),
     make_pair(make_pair(make_symbol("cdr"), make_pair(make_symbol("x"),
-    SYMBOL_NIL)), SYMBOL_NIL)), SYMBOL_NIL)))));
+    SYMBOL_NIL)), SYMBOL_NIL)), SYMBOL_NIL))))), FASTFUNCS->{'cadr'});
 
 $globals{"cddr"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
     make_pair(make_pair(make_symbol("cdr"),
     make_pair(make_pair(make_symbol("cdr"), make_pair(make_symbol("x"),
-    SYMBOL_NIL)), SYMBOL_NIL)), SYMBOL_NIL)))));
+    SYMBOL_NIL)), SYMBOL_NIL)), SYMBOL_NIL))))), FASTFUNCS->{'cddr'});
 
 $globals{"caddr"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
     make_pair(make_pair(make_symbol("car"),
     make_pair(make_pair(make_symbol("cddr"), make_pair(make_symbol("x"),
-    SYMBOL_NIL)), SYMBOL_NIL)), SYMBOL_NIL)))));
+    SYMBOL_NIL)), SYMBOL_NIL)), SYMBOL_NIL))))), FASTFUNCS->{'caddr'});
 
 $globals{"case"} =
     make_pair(make_symbol("lit"), make_pair(make_symbol("mac"),
@@ -610,14 +629,14 @@ $globals{"aif"} =
     SYMBOL_NIL))), SYMBOL_NIL))), SYMBOL_NIL))))), SYMBOL_NIL)));
 
 $globals{"find"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("f"),
-    make_pair(make_symbol("xs"), SYMBOL_NIL)),
-    make_pair(make_pair(make_symbol("aif"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("f"), make_pair(make_symbol("xs"),
+    SYMBOL_NIL)), make_pair(make_pair(make_symbol("aif"),
     make_pair(make_pair(make_symbol("some"), make_pair(make_symbol("f"),
     make_pair(make_symbol("xs"), SYMBOL_NIL))),
     make_pair(make_pair(make_symbol("car"), make_pair(make_symbol("it"),
-    SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL)))));
+    SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL))))), FASTFUNCS->{'find'});
 
 $globals{"begins"} =
     make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -1090,13 +1090,14 @@ $globals{"pairwise"} =
     SYMBOL_NIL))))), FASTFUNCS->{'pairwise'});
 
 $globals{"fuse"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("f"),
-    make_symbol("args")), make_pair(make_pair(make_symbol("apply"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("f"), make_symbol("args")),
+    make_pair(make_pair(make_symbol("apply"),
     make_pair(make_symbol("append"),
     make_pair(make_pair(make_symbol("apply"), make_pair(make_symbol("map"),
     make_pair(make_symbol("f"), make_pair(make_symbol("args"),
-    SYMBOL_NIL)))), SYMBOL_NIL))), SYMBOL_NIL)))));
+    SYMBOL_NIL)))), SYMBOL_NIL))), SYMBOL_NIL))))), FASTFUNCS->{'fuse'});
 
 $globals{"letu"} =
     make_pair(make_symbol("lit"), make_pair(make_symbol("mac"),

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -672,8 +672,9 @@ $globals{"caris"} =
     SYMBOL_NIL))))), FASTFUNCS->{'caris'});
 
 $globals{"hug"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("xs"),
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("xs"),
     make_pair(make_pair(make_symbol("o"), make_pair(make_symbol("f"),
     make_pair(make_symbol("list"), SYMBOL_NIL))), SYMBOL_NIL)),
     make_pair(make_pair(make_symbol("if"),
@@ -693,7 +694,7 @@ $globals{"hug"} =
     make_pair(make_pair(make_symbol("hug"),
     make_pair(make_pair(make_symbol("cddr"), make_pair(make_symbol("xs"),
     SYMBOL_NIL)), make_pair(make_symbol("f"), SYMBOL_NIL))), SYMBOL_NIL))),
-    SYMBOL_NIL)))))), SYMBOL_NIL)))));
+    SYMBOL_NIL)))))), SYMBOL_NIL))))), FASTFUNCS->{'hug'});
 
 $globals{"with"} =
     make_pair(make_symbol("lit"), make_pair(make_symbol("mac"),

--- a/lib/Language/Bel/Globals/FastFuncs.pm
+++ b/lib/Language/Bel/Globals/FastFuncs.pm
@@ -517,6 +517,25 @@ my %FASTFUNCS = (
         return $result;
     },
 
+    "keep" => sub {
+        my ($call, $f, $xs) = @_;
+
+        my @values;
+        while (!is_nil($xs)) {
+            my $value = prim_car($xs);
+            if (!is_nil($call->($f, $value))) {
+                push @values, $value;
+            }
+            $xs = prim_cdr($xs);
+        }
+
+        my $result = SYMBOL_NIL;
+        for my $value (reverse(@values)) {
+            $result = make_pair($value, $result);
+        }
+        return $result;
+    },
+
     "split" => sub {
         my ($call, $f, $xs, $acc) = @_;
 

--- a/lib/Language/Bel/Globals/FastFuncs.pm
+++ b/lib/Language/Bel/Globals/FastFuncs.pm
@@ -480,6 +480,41 @@ my %FASTFUNCS = (
             return SYMBOL_T;
         }
     },
+
+    "split" => sub {
+        my ($call, $f, $xs, $acc) = @_;
+
+        if (!defined($acc)) {
+            $acc = SYMBOL_NIL;
+        }
+        my @acc;
+        while (!is_nil($xs)) {
+            last
+                if !is_pair($xs) || !is_nil($call->($f, prim_car($xs)));
+            push(@acc, prim_car($xs));
+            $xs = prim_cdr($xs);
+        }
+
+        my @prefix;
+        while (!is_nil($acc)) {
+            push(@prefix, prim_car($acc));
+            $acc = prim_cdr($acc);
+        }
+        my $first = SYMBOL_NIL;
+        while (@acc) {
+            $first = make_pair(pop(@acc), $first);
+        }
+        while (@prefix) {
+            $first = make_pair(pop(@prefix), $first);
+        }
+        return make_pair(
+            $first,
+            make_pair(
+                $xs,
+                SYMBOL_NIL,
+            ),
+        );
+    },
 );
 
 sub FASTFUNCS {

--- a/lib/Language/Bel/Globals/FastFuncs.pm
+++ b/lib/Language/Bel/Globals/FastFuncs.pm
@@ -1,0 +1,33 @@
+package Language::Bel::Globals::FastFuncs;
+
+use 5.006;
+use strict;
+use warnings;
+
+use Language::Bel::Types qw(
+    is_nil
+);
+use Language::Bel::Symbols::Common qw(
+    SYMBOL_NIL
+    SYMBOL_T
+);
+
+use Exporter 'import';
+
+my %FASTFUNCS = (
+    "no" => sub {
+        my ($x) = @_;
+
+        return is_nil($x) ? SYMBOL_T : SYMBOL_NIL;
+    },
+);
+
+sub FASTFUNCS {
+    return \%FASTFUNCS;
+}
+
+our @EXPORT_OK = qw(
+    FASTFUNCS
+);
+
+1;

--- a/lib/Language/Bel/Globals/FastFuncs.pm
+++ b/lib/Language/Bel/Globals/FastFuncs.pm
@@ -549,6 +549,20 @@ my %FASTFUNCS = (
         return SYMBOL_T;
     },
 
+    "pairwise" => sub {
+        my ($call, $f, $xs) = @_;
+
+        my $cdr_xs;
+        while (!is_nil($cdr_xs = prim_cdr($xs))) {
+            if (is_nil($call->($f, prim_car($xs), prim_car($cdr_xs)))) {
+                return SYMBOL_NIL;
+            }
+            $xs = $cdr_xs;
+        }
+
+        return SYMBOL_T;
+    },
+
 );
 
 sub FASTFUNCS {

--- a/lib/Language/Bel/Globals/FastFuncs.pm
+++ b/lib/Language/Bel/Globals/FastFuncs.pm
@@ -482,6 +482,41 @@ my %FASTFUNCS = (
         }
     },
 
+    "hug" => sub {
+        my ($call, $xs, $f) = @_;
+
+        my @values;
+        my $cdr_xs;
+        if (defined($f)) {
+            while (!is_nil($cdr_xs = prim_cdr($xs))) {
+                push @values, $call->($f, prim_car($xs), prim_car($cdr_xs));
+                $xs = prim_cdr($cdr_xs);
+            }
+            if (!is_nil($xs)) {
+                push @values, $call->($f, prim_car($xs));
+            }
+        }
+        else {
+            while (!is_nil($cdr_xs = prim_cdr($xs))) {
+                push @values, make_pair(
+                    prim_car($xs),
+                    make_pair(
+                        prim_car($cdr_xs),
+                        SYMBOL_NIL));
+                $xs = prim_cdr($cdr_xs);
+            }
+            if (!is_nil($xs)) {
+                push @values, make_pair(prim_car($xs), SYMBOL_NIL);
+            }
+        }
+
+        my $result = SYMBOL_NIL;
+        for my $value (reverse(@values)) {
+            $result = make_pair($value, $result);
+        }
+        return $result;
+    },
+
     "split" => sub {
         my ($call, $f, $xs, $acc) = @_;
 

--- a/lib/Language/Bel/Globals/FastFuncs.pm
+++ b/lib/Language/Bel/Globals/FastFuncs.pm
@@ -383,6 +383,103 @@ my %FASTFUNCS = (
         }
         return SYMBOL_NIL;
     },
+
+    "begins" => sub {
+        my ($call, $xs, $pat, $f) = @_;
+
+        if (defined($f)) {
+            while (!is_nil($pat)) {
+                if (!is_pair($xs)) {
+                    return SYMBOL_NIL;
+                }
+                else {
+                    my $p = $call->($f, prim_car($xs), prim_car($pat));
+                    if (is_nil($p)) {
+                        return SYMBOL_NIL;
+                    }
+                }
+                $xs = prim_cdr($xs);
+                $pat = prim_cdr($pat);
+            }
+        }
+        else {
+            while (!is_nil($pat)) {
+                if (!is_pair($xs)) {
+                    return SYMBOL_NIL;
+                }
+
+                my @stack = [prim_car($xs), prim_car($pat)];
+                while (@stack) {
+                    my @values = @{pop(@stack)};
+                    next unless @values;
+                    my $some_atom = "";
+                    for my $value (@values) {
+                        if (!is_pair($value)) {
+                            $some_atom = 1;
+                            last;
+                        }
+                    }
+                    if ($some_atom) {
+                        my $car_values = $values[0];
+                        for my $value (@values) {
+                            if (!_id($value, $car_values)) {
+                                return SYMBOL_NIL;
+                            }
+                        }
+                    }
+                    else {
+                        push @stack, [map { prim_cdr($_) } @values];
+                        push @stack, [map { prim_car($_) } @values];
+                    }
+                }
+
+                $xs = prim_cdr($xs);
+                $pat = prim_cdr($pat);
+            }
+        }
+
+        return SYMBOL_T;
+    },
+
+    "caris" => sub {
+        my ($call, $x, $y, $f) = @_;
+
+        if (!is_pair($x)) {
+            return SYMBOL_NIL;
+        }
+
+        if (defined($f)) {
+            return $call->($f, prim_car($x), $y);
+        }
+        else {
+            my @stack = [prim_car($x), $y];
+            while (@stack) {
+                my @values = @{pop(@stack)};
+                next unless @values;
+                my $some_atom = "";
+                for my $value (@values) {
+                    if (!is_pair($value)) {
+                        $some_atom = 1;
+                        last;
+                    }
+                }
+                if ($some_atom) {
+                    my $car_values = $values[0];
+                    for my $value (@values) {
+                        if (!_id($value, $car_values)) {
+                            return SYMBOL_NIL;
+                        }
+                    }
+                }
+                else {
+                    push @stack, [map { prim_cdr($_) } @values];
+                    push @stack, [map { prim_car($_) } @values];
+                }
+            }
+
+            return SYMBOL_T;
+        }
+    },
 );
 
 sub FASTFUNCS {

--- a/lib/Language/Bel/Globals/FastFuncs.pm
+++ b/lib/Language/Bel/Globals/FastFuncs.pm
@@ -5,7 +5,17 @@ use strict;
 use warnings;
 
 use Language::Bel::Types qw(
+    is_char
     is_nil
+    is_pair
+    is_symbol
+    make_pair
+);
+use Language::Bel::Primitives qw(
+    _id
+    prim_car
+    prim_cdr
+    prim_id
 );
 use Language::Bel::Symbols::Common qw(
     SYMBOL_NIL
@@ -16,9 +26,361 @@ use Exporter 'import';
 
 my %FASTFUNCS = (
     "no" => sub {
-        my ($x) = @_;
+        my ($interpreter, $x) = @_;
 
         return is_nil($x) ? SYMBOL_T : SYMBOL_NIL;
+    },
+
+    "atom" => sub {
+        my ($interpreter, $x) = @_;
+
+        return is_pair($x) ? SYMBOL_NIL : SYMBOL_T;
+    },
+
+    "all" => sub {
+        my ($interpreter, $f, $xs) = @_;
+
+        while (!is_nil($xs)) {
+            my $p = $interpreter->run_function_and_return($f, prim_car($xs));
+            if (is_nil($p)) {
+                return SYMBOL_NIL;
+            }
+            $xs = prim_cdr($xs);
+        }
+
+        return SYMBOL_T;
+    },
+
+    "some" => sub {
+        my ($interpreter, $f, $xs) = @_;
+
+        while (!is_nil($xs)) {
+            my $p = $interpreter->run_function_and_return($f, prim_car($xs));
+            if (!is_nil($p)) {
+                return $xs;
+            }
+            $xs = prim_cdr($xs);
+        }
+
+        return SYMBOL_NIL;
+    },
+
+    "reduce" => sub {
+        my ($interpreter, $f, $xs) = @_;
+
+        my @values;
+        while (!is_nil($xs)) {
+            push @values, prim_car($xs);
+            $xs = prim_cdr($xs);
+        }
+
+        my $result = @values ? pop(@values) : SYMBOL_NIL;
+        while (@values) {
+            my $value = pop(@values);
+            $result = $interpreter->run_function_and_return($f, $value, $result);
+        }
+
+        return $result;
+    },
+
+    "cons" => sub {
+        my ($interpreter, @args) = @_;
+
+        my $result = @args ? pop(@args) : SYMBOL_NIL;
+        while (@args) {
+            my $value = pop(@args);
+            $result = make_pair($value, $result);
+        }
+
+        return $result;
+    },
+
+    "append" => sub {
+        my ($interpreter, @args) = @_;
+
+        my $result = @args ? pop(@args) : SYMBOL_NIL;
+        while (@args) {
+            my $list = pop(@args);
+            my @values;
+            while (!is_nil($list)) {
+                push @values, prim_car($list);
+                $list = prim_cdr($list);
+            }
+            while (@values) {
+                my $value = pop(@values);
+                $result = make_pair($value, $result);
+            }
+        }
+
+        return $result;
+    },
+
+    "snoc" => sub {
+        my ($interpreter, @args) = @_;
+
+        my $result = SYMBOL_NIL;
+        while (scalar(@args) > 1) {
+            my $value = pop(@args);
+            $result = make_pair($value, $result);
+        }
+        if (@args) {
+            my $list = pop(@args);
+            my @values;
+            while (!is_nil($list)) {
+                push @values, prim_car($list);
+                $list = prim_cdr($list);
+            }
+            while (@values) {
+                my $value = pop(@values);
+                $result = make_pair($value, $result);
+            }
+        }
+
+        return $result;
+    },
+
+    "list" => sub {
+        my ($interpreter, @args) = @_;
+
+        my $result = SYMBOL_NIL;
+        while (@args) {
+            my $value = pop(@args);
+            $result = make_pair($value, $result);
+        }
+
+        return $result;
+    },
+
+    "map" => sub {
+        my ($interpreter, $f, @ls) = @_;
+
+        return SYMBOL_NIL
+            unless @ls;
+        my @sublists;
+        my $min_length = -1;
+        for my $list (@ls) {
+            my @sublist;
+            while (!is_nil($list)) {
+                push @sublist, prim_car($list);
+                $list = prim_cdr($list);
+            }
+            push @sublists, \@sublist;
+            my $length = scalar(@sublist);
+            $min_length = $min_length == -1 || $length < $min_length
+                ? $length
+                : $min_length;
+        }
+        my @result;
+        for my $i (0..$min_length-1) {
+            push @result, $interpreter->run_function_and_return(
+                $f,
+                map { $sublists[$_]->[$i] } 0..$#sublists
+            );
+        }
+        my $result = SYMBOL_NIL;
+        for my $v (reverse(@result)) {
+            $result = make_pair($v, $result);
+        }
+
+        return $result;
+    },
+
+    "=" => sub {
+        my ($interpreter, @args) = @_;
+
+        my @stack = [@args];
+        while (@stack) {
+            my @values = @{pop(@stack)};
+            next unless @values;
+            my $some_atom = "";
+            for my $value (@values) {
+                if (!is_pair($value)) {
+                    $some_atom = 1;
+                    last;
+                }
+            }
+            if ($some_atom) {
+                my $car_values = $values[0];
+                for my $value (@values) {
+                    if (!_id($value, $car_values)) {
+                        return SYMBOL_NIL;
+                    }
+                }
+            }
+            else {
+                push @stack, [map { prim_cdr($_) } @values];
+                push @stack, [map { prim_car($_) } @values];
+            }
+        }
+
+        return SYMBOL_T;
+    },
+
+    "symbol" => sub {
+        my ($interpreter, $x) = @_;
+
+        return is_symbol($x) ? SYMBOL_T : SYMBOL_NIL;
+    },
+
+    "pair" => sub {
+        my ($interpreter, $x) = @_;
+
+        return is_pair($x) ? SYMBOL_T : SYMBOL_NIL;
+    },
+
+    "char" => sub {
+        my ($interpreter, $x) = @_;
+
+        return is_char($x) ? SYMBOL_T : SYMBOL_NIL;
+    },
+
+    "proper" => sub {
+        my ($interpreter, $x) = @_;
+
+        while (!is_nil($x)) {
+            if (!is_pair($x)) {
+                return SYMBOL_NIL;
+            }
+            $x = prim_cdr($x);
+        }
+
+        return SYMBOL_T;
+    },
+
+    "string" => sub {
+        my ($interpreter, $x) = @_;
+
+        while (!is_nil($x)) {
+            if (!is_pair($x)) {
+                return SYMBOL_NIL;
+            }
+            if (!is_char(prim_car($x))) {
+                return SYMBOL_NIL;
+            }
+            $x = prim_cdr($x);
+        }
+
+        return SYMBOL_T;
+    },
+
+    "mem" => sub {
+        my ($interpreter, $x, $ys, $f) = @_;
+
+        while (!is_nil($ys)) {
+            my $p;
+            if (defined($f)) {
+                $p = $interpreter->run_function_and_return($f, prim_car($ys), $x);
+            }
+            else {
+                my @stack = [prim_car($ys), $x];
+                while (@stack) {
+                    my @values = @{pop(@stack)};
+                    next unless @values;
+                    my $some_atom = "";
+                    for my $value (@values) {
+                        if (!is_pair($value)) {
+                            $some_atom = 1;
+                            last;
+                        }
+                    }
+                    if ($some_atom) {
+                        my $car_values = $values[0];
+                        for my $value (@values) {
+                            if (!_id($value, $car_values)) {
+                                $p = SYMBOL_NIL;
+                                goto COMPARED;
+                            }
+                        }
+                    }
+                    else {
+                        push @stack, [map { prim_cdr($_) } @values];
+                        push @stack, [map { prim_car($_) } @values];
+                    }
+                }
+
+                $p = SYMBOL_T;
+            }
+            COMPARED:
+            if (!is_nil($p)) {
+                return $ys;
+            }
+            $ys = prim_cdr($ys);
+        }
+
+        return SYMBOL_NIL;
+    },
+
+    "in" => sub {
+        my ($interpreter, @args) = @_;
+
+        my $x = @args ? shift(@args) : SYMBOL_NIL;
+
+        ARG:
+        while (@args) {
+            my @stack = [$args[0], $x];
+            while (@stack) {
+                my @values = @{pop(@stack)};
+                next unless @values;
+                my $some_atom = "";
+                for my $value (@values) {
+                    if (!is_pair($value)) {
+                        $some_atom = 1;
+                        last;
+                    }
+                }
+                if ($some_atom) {
+                    my $car_values = $values[0];
+                    for my $value (@values) {
+                        if (!_id($value, $car_values)) {
+                            shift(@args);
+                            next ARG;
+                        }
+                    }
+                }
+                else {
+                    push @stack, [map { prim_cdr($_) } @values];
+                    push @stack, [map { prim_car($_) } @values];
+                }
+            }
+            last ARG;
+        }
+
+        my $ys = SYMBOL_NIL;
+        while (@args) {
+            $ys = make_pair(pop(@args), $ys);
+        }
+        return $ys;
+    },
+
+    "cadr" => sub {
+        my ($interpreter, $x) = @_;
+
+        return prim_car(prim_cdr($x));
+    },
+
+    "cddr" => sub {
+        my ($interpreter, $x) = @_;
+
+        return prim_cdr(prim_cdr($x));
+    },
+
+    "caddr" => sub {
+        my ($interpreter, $x) = @_;
+
+        return prim_car(prim_cdr(prim_cdr($x)));
+    },
+
+    "find" => sub {
+        my ($interpreter, $f, $xs) = @_;
+
+        while (!is_nil($xs)) {
+            my $value = prim_car($xs);
+            if (!is_nil($interpreter->run_function_and_return($f, $value))) {
+                return $value;
+            }
+            $xs = prim_cdr($xs);
+        }
+        return SYMBOL_NIL;
     },
 );
 

--- a/lib/Language/Bel/Globals/FastFuncs.pm
+++ b/lib/Language/Bel/Globals/FastFuncs.pm
@@ -563,6 +563,39 @@ my %FASTFUNCS = (
         return SYMBOL_T;
     },
 
+    "foldl" => sub {
+        my ($call, $f, $base, @args) = @_;
+
+        return $base
+            unless @args;
+
+        while (!grep { is_nil($_) } @args) {
+            my @car_args = map { prim_car($_) } @args;
+            $base = $call->($f, @car_args, $base);
+            @args = map { prim_cdr($_) } @args;
+        }
+
+        return $base;
+    },
+
+    "foldr" => sub {
+        my ($call, $f, $base, @args) = @_;
+
+        return $base
+            unless @args;
+
+        my @cars;
+        while (!grep { is_nil($_) } @args) {
+            push @cars, [map { prim_car($_) } @args];
+            @args = map { prim_cdr($_) } @args;
+        }
+
+        for my $cars (reverse(@cars)) {
+            $base = $call->($f, @{$cars}, $base);
+        }
+
+        return $base;
+    },
 );
 
 sub FASTFUNCS {

--- a/lib/Language/Bel/Globals/Generator.pm
+++ b/lib/Language/Bel/Globals/Generator.pm
@@ -9,6 +9,7 @@ use Language::Bel::Types qw(
     is_pair
     is_symbol
     is_symbol_of_name
+    make_fastfunc
     make_pair
     make_symbol
     pair_car
@@ -37,6 +38,9 @@ use Language::Bel::Expander::Bquote qw(
     _bqexpand
 );
 use Language::Bel::Globals::Source;
+use Language::Bel::Globals::FastFuncs qw(
+    FASTFUNCS
+);
 use Language::Bel::Interpreter;
 
 use Exporter 'import';
@@ -90,6 +94,7 @@ use warnings;
 use Language::Bel::Types qw(
     make_pair
     make_symbol
+    make_fastfunc
 );
 use Language::Bel::Symbols::Common qw(
     SYMBOL_CHAR
@@ -101,6 +106,9 @@ use Language::Bel::Symbols::Common qw(
 );
 use Language::Bel::Primitives qw(
     PRIMITIVES
+);
+use Language::Bel::Globals::FastFuncs qw(
+    FASTFUNCS
 );
 
 use Exporter 'import';
@@ -226,7 +234,10 @@ sub print_global {
     my ($name, $value) = @_;
 
     my $serialized = serialize($value);
-    my $formatted = break_lines($serialized);
+    my $maybe_ff_d = FASTFUNCS->{$name}
+        ? "make_fastfunc($serialized, FASTFUNCS->{'$name'})"
+        : $serialized;
+    my $formatted = break_lines($maybe_ff_d);
     print('$globals{"', $name, '"} =', "\n");
     print("$formatted;\n");
     print("\n");

--- a/lib/Language/Bel/Interpreter.pm
+++ b/lib/Language/Bel/Interpreter.pm
@@ -70,19 +70,24 @@ sub new {
         $self->{call} = sub {
             my ($fn, @args) = @_;
 
-            my $args = SYMBOL_NIL;
-            for my $arg (reverse(@args)) {
-                $args = make_pair($arg, $args);
+            if (is_fastfunc($fn)) {
+                return $fn->apply($self->{call}, @args);
             }
+            else {
+                my $args = SYMBOL_NIL;
+                for my $arg (reverse(@args)) {
+                    $args = make_pair($arg, $args);
+                }
 
-            my $s_level = scalar(@{$self->{s}});
-            $self->applyf($fn, $args, SYMBOL_NIL);
+                my $s_level = scalar(@{$self->{s}});
+                $self->applyf($fn, $args, SYMBOL_NIL);
 
-            while (scalar(@{$self->{s}}) > $s_level) {
-                $self->ev();
+                while (scalar(@{$self->{s}}) > $s_level) {
+                    $self->ev();
+                }
+                my $retval = pop(@{$self->{r}});
+                return $retval;
             }
-            my $retval = pop(@{$self->{r}});
-            return $retval;
         };
     }
 

--- a/lib/Language/Bel/Type/Pair/FastFunc.pm
+++ b/lib/Language/Bel/Type/Pair/FastFunc.pm
@@ -9,9 +9,9 @@ sub new {
 }
 
 sub apply {
-    my ($self, @args) = @_;
+    my ($self, $interpreter, @args) = @_;
 
-    return $self->{fn}->(@args);
+    return $self->{fn}->($interpreter, @args);
 }
 
 1;

--- a/lib/Language/Bel/Type/Pair/FastFunc.pm
+++ b/lib/Language/Bel/Type/Pair/FastFunc.pm
@@ -1,0 +1,11 @@
+package Language::Bel::Type::Pair::FastFunc;
+use base qw(Language::Bel::Type::Pair);
+
+sub new {
+    my ($class, $pair, $fn) = @_;
+
+    my $obj = { car => $pair->{car}, cdr => $pair->{cdr}, fn => $fn };
+    return bless($obj, $class);
+}
+
+1;

--- a/lib/Language/Bel/Type/Pair/FastFunc.pm
+++ b/lib/Language/Bel/Type/Pair/FastFunc.pm
@@ -8,4 +8,10 @@ sub new {
     return bless($obj, $class);
 }
 
+sub apply {
+    my ($self, @args) = @_;
+
+    return $self->{fn}->(@args);
+}
+
 1;

--- a/lib/Language/Bel/Types.pm
+++ b/lib/Language/Bel/Types.pm
@@ -15,7 +15,7 @@ sub char_name {
 sub is_char {
     my ($object) = @_;
 
-    return ref($object) eq "Language::Bel::Type::Char";
+    return $object->isa("Language::Bel::Type::Char");
 }
 
 sub is_nil {
@@ -27,7 +27,7 @@ sub is_nil {
 sub is_pair {
     my ($object) = @_;
 
-    return ref($object) eq "Language::Bel::Type::Pair";
+    return $object->isa("Language::Bel::Type::Pair");
 }
 
 sub is_string {
@@ -43,7 +43,7 @@ sub is_string {
 sub is_symbol {
     my ($object) = @_;
 
-    return ref($object) eq "Language::Bel::Type::Symbol";
+    return $object->isa("Language::Bel::Type::Symbol");
 }
 
 sub is_symbol_of_name {

--- a/lib/Language/Bel/Types.pm
+++ b/lib/Language/Bel/Types.pm
@@ -2,6 +2,7 @@ package Language::Bel::Types;
 
 use Language::Bel::Type::Char;
 use Language::Bel::Type::Pair;
+use Language::Bel::Type::Pair::FastFunc;
 use Language::Bel::Type::Symbol;
 
 use Exporter 'import';
@@ -16,6 +17,12 @@ sub is_char {
     my ($object) = @_;
 
     return $object->isa("Language::Bel::Type::Char");
+}
+
+sub is_fastfunc {
+    my ($object) = @_;
+
+    return $object->isa("Language::Bel::Type::Pair::FastFunc");
 }
 
 sub is_nil {
@@ -56,6 +63,12 @@ sub make_char {
     my ($name) = @_;
 
     return Language::Bel::Type::Char->new($name);
+}
+
+sub make_fastfunc {
+    my ($pair, $fn) = @_;
+
+    return Language::Bel::Type::Pair::FastFunc->new($pair, $fn);
 }
 
 sub make_pair {
@@ -109,12 +122,14 @@ sub symbol_name {
 our @EXPORT_OK = qw(
     char_name
     is_char
+    is_fastfunc
     is_nil
     is_pair
     is_string
     is_symbol
     is_symbol_of_name
     make_char
+    make_fastfunc
     make_pair
     make_symbol
     pair_car


### PR DESCRIPTION
Well, this was an interesting exercise.

On the one hand, the test suite drops from 574 s to 35 s &mdash; a 94% decrease &mdash; which has to be considered some kind of a win.

On the other hand, having to implement Bel code with Perl code has to be considered some kind of defeat. It's a situation I consider to be temporary, though, as we move towards an optimizing compiler that can help us generate code very much like this.

In the meantime, we can enjoy a faster Bel, which is not so bad.