### PR TITLE
Support virtual functions and implement nth

### DIFF
--- a/lib/Language/Bel.pm
+++ b/lib/Language/Bel.pm
@@ -57,11 +57,11 @@ Language::Bel - An interpreter for Paul Graham's language Bel
 
 =head1 VERSION
 
-Version 0.28
+Version 0.29
 
 =cut
 
-our $VERSION = '0.28';
+our $VERSION = '0.29';
 
 =head1 SYNOPSIS
 

--- a/lib/Language/Bel.pm
+++ b/lib/Language/Bel.pm
@@ -768,6 +768,48 @@ sub applylit {
         }
         # XXX: skipping `mac` case for now
         # XXX: skipping `cont` case for now
+        else {
+            my $virfns = pair_cdr(get(make_symbol("virfns"), $self->{g}));
+            my $it;
+            if ($it = get($tag, $virfns)) {
+                my $cdr_it = prim_cdr($it);
+                my @stack;
+                while (!is_nil($args)) {
+                    push @stack, prim_car($args);
+                    $args = prim_cdr($args);
+                }
+                my $quoted_args = SYMBOL_NIL;
+                while (@stack) {
+                    my $arg = pop(@stack);
+                    $quoted_args = make_pair(
+                        make_pair(
+                            make_symbol("quote"),
+                            make_pair(
+                                $arg,
+                                SYMBOL_NIL,
+                            ),
+                        ),
+                        $quoted_args,
+                    );
+                }
+                my $f_and_quoted_args = make_pair(
+                    $f,
+                    make_pair(
+                        $quoted_args,
+                        SYMBOL_NIL,
+                    ),
+                );
+                my $fu = fut(sub {
+                    my $virfn_result = pop @{$self->{r}};
+                    push @{$self->{s}}, [$virfn_result, $a];
+                });
+                push @{$self->{s}}, $fu;
+                $self->applyf($cdr_it, $f_and_quoted_args, $a);
+            }
+            else {
+                die "'unapplyable\n";
+            }
+        }
     }
 }
 

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -2961,6 +2961,30 @@ $globals{"pull"} =
     make_pair(SYMBOL_NIL, SYMBOL_NIL))), SYMBOL_NIL))), SYMBOL_NIL))),
     SYMBOL_NIL))), SYMBOL_NIL))), SYMBOL_NIL))))), SYMBOL_NIL)));
 
+$globals{"nth"} =
+    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
+    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("n"),
+    make_pair(make_symbol("xs"), SYMBOL_NIL)),
+    make_pair(make_pair(make_symbol("if"),
+    make_pair(make_pair(make_symbol("="), make_pair(make_symbol("n"),
+    make_pair(make_pair(make_symbol("lit"), make_pair(make_symbol("num"),
+    make_pair(make_pair(make_symbol("+"), make_pair(make_pair(SYMBOL_T,
+    SYMBOL_NIL), make_pair(make_pair(SYMBOL_T, SYMBOL_NIL), SYMBOL_NIL))),
+    make_pair(make_pair(make_symbol("+"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(SYMBOL_T, SYMBOL_NIL), SYMBOL_NIL))),
+    SYMBOL_NIL)))), SYMBOL_NIL))), make_pair(make_pair(make_symbol("car"),
+    make_pair(make_symbol("xs"), SYMBOL_NIL)),
+    make_pair(make_pair(make_symbol("nth"),
+    make_pair(make_pair(make_symbol("-"), make_pair(make_symbol("n"),
+    make_pair(make_pair(make_symbol("lit"), make_pair(make_symbol("num"),
+    make_pair(make_pair(make_symbol("+"), make_pair(make_pair(SYMBOL_T,
+    SYMBOL_NIL), make_pair(make_pair(SYMBOL_T, SYMBOL_NIL), SYMBOL_NIL))),
+    make_pair(make_pair(make_symbol("+"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(SYMBOL_T, SYMBOL_NIL), SYMBOL_NIL))),
+    SYMBOL_NIL)))), SYMBOL_NIL))), make_pair(make_pair(make_symbol("cdr"),
+    make_pair(make_symbol("xs"), SYMBOL_NIL)), SYMBOL_NIL))),
+    SYMBOL_NIL)))), SYMBOL_NIL)))));
+
 $globals{"pop"} =
     make_pair(make_symbol("lit"), make_pair(make_symbol("mac"),
     make_pair(make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -857,6 +857,44 @@ $globals{"isa"} =
     SYMBOL_NIL))), make_pair(make_symbol("id"), SYMBOL_NIL)))),
     SYMBOL_NIL))), SYMBOL_NIL)))));
 
+$globals{"virfns"} =
+    make_pair(make_pair(make_symbol("num"), make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_pair(make_symbol("f"), make_pair(make_symbol("args"),
+    SYMBOL_NIL)), make_pair(make_pair(make_symbol("cons"),
+    make_pair(make_pair(SYMBOL_QUOTE, make_pair(make_symbol("nth"),
+    SYMBOL_NIL)), make_pair(make_pair(make_symbol("cons"),
+    make_pair(make_symbol("f"), make_pair(make_pair(make_symbol("append"),
+    make_pair(make_symbol("args"), make_pair(SYMBOL_NIL, SYMBOL_NIL))),
+    SYMBOL_NIL))), SYMBOL_NIL))), SYMBOL_NIL)))))), SYMBOL_NIL);
+
+$globals{"vir"} =
+    make_pair(make_symbol("lit"), make_pair(make_symbol("mac"),
+    make_pair(make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
+    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("tag"),
+    make_symbol("rest")), make_pair(make_pair(make_symbol("cons"),
+    make_pair(make_pair(SYMBOL_QUOTE, make_pair(make_symbol("set"),
+    SYMBOL_NIL)), make_pair(make_pair(make_symbol("cons"),
+    make_pair(make_pair(SYMBOL_QUOTE, make_pair(make_symbol("virfns"),
+    SYMBOL_NIL)), make_pair(make_pair(make_symbol("cons"),
+    make_pair(make_pair(make_symbol("cons"),
+    make_pair(make_pair(SYMBOL_QUOTE, make_pair(make_symbol("put"),
+    SYMBOL_NIL)), make_pair(make_pair(make_symbol("cons"),
+    make_pair(make_pair(make_symbol("cons"),
+    make_pair(make_pair(SYMBOL_QUOTE, make_pair(SYMBOL_QUOTE, SYMBOL_NIL)),
+    make_pair(make_pair(make_symbol("cons"), make_pair(make_symbol("tag"),
+    make_pair(SYMBOL_NIL, SYMBOL_NIL))), SYMBOL_NIL))),
+    make_pair(make_pair(make_symbol("cons"),
+    make_pair(make_pair(make_symbol("cons"),
+    make_pair(make_pair(SYMBOL_QUOTE, make_pair(make_symbol("fn"),
+    SYMBOL_NIL)), make_pair(make_pair(make_symbol("append"),
+    make_pair(make_symbol("rest"), make_pair(SYMBOL_NIL, SYMBOL_NIL))),
+    SYMBOL_NIL))), make_pair(make_pair(SYMBOL_QUOTE,
+    make_pair(make_pair(make_symbol("virfns"), SYMBOL_NIL), SYMBOL_NIL)),
+    SYMBOL_NIL))), SYMBOL_NIL))), SYMBOL_NIL))), make_pair(SYMBOL_NIL,
+    SYMBOL_NIL))), SYMBOL_NIL))), SYMBOL_NIL))), SYMBOL_NIL))))),
+    SYMBOL_NIL)));
+
 $globals{"function"} =
     make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
     make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),

--- a/lib/Language/Bel/Globals/Generator.pm
+++ b/lib/Language/Bel/Globals/Generator.pm
@@ -238,6 +238,32 @@ HEADER
             }
             next DECLARATION;
         }
+        elsif (symbol_name($car_ast) eq "vir") {
+            my $tag = prim_car(prim_cdr($ast));
+            my $rest = prim_cdr(prim_cdr($ast));
+            for my $global (@globals) {
+                if ($global->{name} eq "virfns") {
+                    $global->{expr} = make_pair(
+                        make_pair(
+                            $tag,
+                            make_pair(
+                                make_symbol("lit"),
+                                make_pair(
+                                    make_symbol("clo"),
+                                    make_pair(
+                                        SYMBOL_NIL,
+                                        _bqexpand($rest),
+                                    ),
+                                ),
+                            ),
+                        ),
+                        $global->{expr},
+                    );
+                    last;
+                }
+            }
+            next;
+        }
         else {
             die "Unrecognized: $declaration";
         }

--- a/lib/Language/Bel/Globals/Generator.pm
+++ b/lib/Language/Bel/Globals/Generator.pm
@@ -128,6 +128,8 @@ HEADER
         print_primitive($prim_name);
     }
 
+    my @globals;
+
     DECLARATION:
     for my $declaration (@DECLARATIONS) {
         my $ast = _read($declaration);
@@ -225,7 +227,10 @@ HEADER
         elsif (symbol_name($car_ast) eq "set") {
             while (!is_nil(prim_cdr($ast))) {
                 $new_ast = prim_car($cddr_ast);
-                print_global($name, $interpreter->eval_ast(_bqexpand($new_ast)));
+                push @globals, {
+                    name => $name,
+                    expr => $interpreter->eval_ast(_bqexpand($new_ast)),
+                };
 
                 $ast = prim_cdr(prim_cdr($ast));
                 $name = symbol_name(prim_car(prim_cdr($ast)));
@@ -237,7 +242,14 @@ HEADER
             die "Unrecognized: $declaration";
         }
 
-        print_global($name, $interpreter->eval_ast(_bqexpand($new_ast)));
+        push @globals, {
+            name => $name,
+            expr => $interpreter->eval_ast(_bqexpand($new_ast)),
+        };
+    }
+
+    for my $global (@globals) {
+        print_global($global->{name}, $global->{expr});
     }
 
     print <<'FOOTER';

--- a/lib/Language/Bel/Globals/Source.pm
+++ b/lib/Language/Bel/Globals/Source.pm
@@ -621,6 +621,11 @@ __DATA__
 
 ; we are here currently, implementing things
 
+(def nth (n xs)     ; n|pint xs|pair
+  (if (= n 1)
+      (car xs)
+      (nth (- n 1) (cdr xs))))
+
 (vir num (f args)
   `(nth ,f ,@args))
 

--- a/lib/Language/Bel/Globals/Source.pm
+++ b/lib/Language/Bel/Globals/Source.pm
@@ -218,6 +218,13 @@ __DATA__
 
 ; skipping the evaluator for now
 
+(set virfns nil)
+
+(mac vir (tag . rest)
+  `(set virfns (put ',tag (fn ,@rest) virfns)))
+
+; back to skipping the evaluator
+
 (def function (x)
   (find [(isa _) x] '(prim clo)))
 
@@ -614,11 +621,18 @@ __DATA__
 
 ; we are here currently, implementing things
 
+(vir num (f args)
+  `(nth ,f ,@args))
+
+; skip
+
 (mac pop (place)
   `(let (cell loc) (where ,place)
      (let xs ((case loc a car d cdr) cell)
        ((case loc a xar d xdr) cell (cdr xs))
        (car xs))))
+
+; skip
 
 (def err args)
 

--- a/t/virfns.t
+++ b/t/virfns.t
@@ -1,0 +1,29 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings;
+use Test::More;
+
+use Language::Bel;
+
+plan tests => 2;
+
+my $actual_output = "";
+my $b = Language::Bel->new({ output => sub {
+    my ($string) = @_;
+    $actual_output = "$actual_output$string";
+} });
+
+sub is_bel_output {
+    my ($expr, $expected_output) = @_;
+
+    $actual_output = "";
+    $b->eval($expr);
+
+    is($actual_output, $expected_output, "$expr ==> $expected_output");
+}
+
+{
+    is_bel_output("(2 '(a b c))", "b");
+    is_bel_output("(do (push (cons 'num (fn (f args) ''haha)) virfns) (2 '(a b c)))", "haha");
+}


### PR DESCRIPTION
This work has been stuck in a branch <del>the later part of which has some problems</del>. But the two commits at the beginning of the branch represent a step forward, and I'd prefer to push them through review and into `master` rather than have them sit unused in a branch.

The work itself represents being able to put `vir` declarations among the globals, and to have them code-generate in `Globals.pm` in the right way. In order to have that happen, we first need to scan all the globals, and then start emitting them, rather than scanning-and-emitting at the same time.

With this work merged, we could also start on comparison operators and `comfns`, which need the same mechanism.

**Edit:** A commented-out part below have been solved, and everything works now.

<!--
The second part of this work would be to actually _support_ virtual functions in the evaluator, not just have them present among the globals. The reason this part is experiencing some problems, near as I can tell, has something to do with the bquote mechanism. I get this (in the non-working, unpublished commits):

```
$ perl -Ilib bin/bel
Language::Bel 0.29 -- msys.
> (2 '(a b c))
'underargs
```

But this works:

```
> (nth 2 '(a b c))
b
```

And this works:

```
> (fn (f args) `(nth ,f ,@args))
(lit clo nil (f args) (bquote (nth (comma f) (comma-at args))))
> virfns
((num lit clo nil (f args) (bquote (nth (comma f) (comma-at args)))))
> (= (fn (f args) `(nth ,f ,@args)) (cdr:get 'num virfns))
t
```

So I feel like the only non-working part is the bquote mechanism itself; indeed the code dies somewhere inside of it.

In fact, _this_ fails, and it definitely shouldn't:

```
> `(x)
'underargs
```

So, current plan: get this PR through, start working on `comfns`, try fixing the bquote mechanism in a separate branch/PR. (Oh! Probably also create an issue to track that.) Finally, after that, get virtual function calls to work.
-->

Closes #83.