### PR TITLE
Introduce fake 'pr' and 'prn' functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Language::Bel 0.34 -- msys.
 It's not fully there yet, though it's under active development.
 
 [The spec](https://github.com/masak/bel/blob/master/pg/bel.bel) contains 353 items.
-`Language::Bel` currently defines 222 of them.
+`Language::Bel` currently defines 223 of them.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Language::Bel 0.34 -- msys.
 It's not fully there yet, though it's under active development.
 
 [The spec](https://github.com/masak/bel/blob/master/pg/bel.bel) contains 353 items.
-`Language::Bel` currently defines 224 of them.
+`Language::Bel` currently defines 225 of them.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Language::Bel 0.34 -- msys.
 It's not fully there yet, though it's under active development.
 
 [The spec](https://github.com/masak/bel/blob/master/pg/bel.bel) contains 353 items.
-`Language::Bel` currently defines 223 of them.
+`Language::Bel` currently defines 224 of them.
 
 ## Contributing
 

--- a/lib/Language/Bel.pm
+++ b/lib/Language/Bel.pm
@@ -23,15 +23,13 @@ use Language::Bel::Symbols::Common qw(
     SYMBOL_T
 );
 use Language::Bel::Primitives qw(
-    PRIMITIVES
-);
-use Language::Bel::Primitives qw(
     _id
     prim_car
     prim_cdr
     prim_type
     prim_xdr
     PRIM_FN
+    PRIMITIVES
 );
 use Language::Bel::Reader qw(
     read_whole

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -4744,6 +4744,15 @@ $globals{"record"} =
     SYMBOL_NIL))), SYMBOL_NIL))), SYMBOL_NIL))), SYMBOL_NIL))),
     SYMBOL_NIL))))), SYMBOL_NIL)));
 
+$globals{"prs"} =
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_symbol("args"),
+    make_pair(make_pair(make_symbol("record"),
+    make_pair(make_pair(make_symbol("apply"), make_pair(make_symbol("pr"),
+    make_pair(make_symbol("args"), SYMBOL_NIL))), SYMBOL_NIL)),
+    SYMBOL_NIL))))), FASTFUNCS->{'prs'});
+
 $globals{"array"} =
     make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
     make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("dims"),

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -3378,10 +3378,11 @@ $globals{"splice"} =
     SYMBOL_NIL)), SYMBOL_NIL)), SYMBOL_NIL))))), SYMBOL_NIL)));
 
 $globals{"pr"} =
-    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_symbol("args"),
-    make_pair(make_pair(make_symbol("map"), make_pair(make_symbol("prnice"),
-    make_pair(make_symbol("args"), SYMBOL_NIL))), SYMBOL_NIL)))));
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_symbol("args"), make_pair(make_pair(make_symbol("map"),
+    make_pair(make_symbol("prnice"), make_pair(make_symbol("args"),
+    SYMBOL_NIL))), SYMBOL_NIL))))), FASTFUNCS->{'pr'});
 
 $globals{"drop"} =
     make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -3377,6 +3377,12 @@ $globals{"splice"} =
     make_pair(make_symbol("comma-at-outside-list"), SYMBOL_NIL)),
     SYMBOL_NIL)), SYMBOL_NIL)), SYMBOL_NIL))))), SYMBOL_NIL)));
 
+$globals{"pr"} =
+    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
+    make_pair(SYMBOL_NIL, make_pair(make_symbol("args"),
+    make_pair(make_pair(make_symbol("map"), make_pair(make_symbol("prnice"),
+    make_pair(make_symbol("args"), SYMBOL_NIL))), SYMBOL_NIL)))));
+
 $globals{"drop"} =
     make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
     make_pair(SYMBOL_NIL, make_pair(make_pair(make_pair(SYMBOL_T,
@@ -3654,7 +3660,8 @@ $globals{"ceil"} =
     SYMBOL_NIL)))))), SYMBOL_NIL)))))),
     make_pair(make_pair(make_symbol("f"), make_pair(make_symbol("lit"),
     make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
-    make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
+    make_pair(make_pair(make_pair(SYMBOL_T, make_pair(make_symbol("x"),
+    make_pair(make_symbol("real"), SYMBOL_NIL))), SYMBOL_NIL),
     make_pair(make_pair(make_symbol("let"),
     make_pair(make_pair(make_symbol("s"), make_pair(make_symbol("n"),
     make_pair(make_symbol("d"), SYMBOL_NIL))),
@@ -3697,8 +3704,9 @@ $globals{"ceil"} =
     SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL)), SYMBOL_NIL))),
     SYMBOL_NIL)))))), SYMBOL_NIL))))),
     make_pair(make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
-    make_pair(make_pair(make_symbol("let"),
+    make_pair(SYMBOL_NIL, make_pair(make_pair(make_pair(SYMBOL_T,
+    make_pair(make_symbol("x"), make_pair(make_symbol("real"),
+    SYMBOL_NIL))), SYMBOL_NIL), make_pair(make_pair(make_symbol("let"),
     make_pair(make_pair(make_symbol("s"), make_pair(make_symbol("n"),
     make_pair(make_symbol("d"), SYMBOL_NIL))),
     make_pair(make_pair(make_symbol("numr"), make_pair(make_symbol("x"),
@@ -3784,8 +3792,9 @@ $globals{"ceil"} =
     SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL)), SYMBOL_NIL))),
     SYMBOL_NIL)))))), SYMBOL_NIL))))),
     make_pair(make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
-    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("x"), SYMBOL_NIL),
-    make_pair(make_pair(make_symbol("let"),
+    make_pair(SYMBOL_NIL, make_pair(make_pair(make_pair(SYMBOL_T,
+    make_pair(make_symbol("x"), make_pair(make_symbol("real"),
+    SYMBOL_NIL))), SYMBOL_NIL), make_pair(make_pair(make_symbol("let"),
     make_pair(make_pair(make_symbol("s"), make_pair(make_symbol("n"),
     make_pair(make_symbol("d"), SYMBOL_NIL))),
     make_pair(make_pair(make_symbol("numr"), make_pair(make_symbol("x"),

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -3377,6 +3377,23 @@ $globals{"splice"} =
     make_pair(make_symbol("comma-at-outside-list"), SYMBOL_NIL)),
     SYMBOL_NIL)), SYMBOL_NIL)), SYMBOL_NIL))))), SYMBOL_NIL)));
 
+$globals{"prn"} =
+    make_fastfunc(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
+    make_pair(make_symbol("args"), make_pair(make_pair(make_symbol("do"),
+    make_pair(make_pair(make_symbol("map"),
+    make_pair(make_pair(make_symbol("fn"),
+    make_pair(make_pair(make_symbol("_"), SYMBOL_NIL),
+    make_pair(make_pair(make_symbol("do"),
+    make_pair(make_pair(make_symbol("print"), make_pair(make_symbol("_"),
+    SYMBOL_NIL)), make_pair(make_pair(make_symbol("prc"),
+    make_pair(make_char(32), SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL))),
+    make_pair(make_symbol("args"), SYMBOL_NIL))),
+    make_pair(make_pair(make_symbol("prc"), make_pair(make_char(10),
+    SYMBOL_NIL)), make_pair(make_pair(make_symbol("last"),
+    make_pair(make_symbol("args"), SYMBOL_NIL)), SYMBOL_NIL)))),
+    SYMBOL_NIL))))), FASTFUNCS->{'prn'});
+
 $globals{"pr"} =
     make_fastfunc(make_pair(make_symbol("lit"),
     make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,

--- a/lib/Language/Bel/Globals/FastFuncs.pm
+++ b/lib/Language/Bel/Globals/FastFuncs.pm
@@ -1336,6 +1336,19 @@ my %FASTFUNCS = (
         );
     },
 
+    "prn" => sub {
+        my ($call, @args) = @_;
+
+        my $last = SYMBOL_NIL;
+        for (@args) {
+            print(Language::Bel::Printer::_print($_));
+            print(" ");
+            $last = $_;
+        }
+        print("\n");
+        return $last;
+    },
+
     "pr" => sub {
         my ($call, @args) = @_;
 

--- a/lib/Language/Bel/Globals/FastFuncs.pm
+++ b/lib/Language/Bel/Globals/FastFuncs.pm
@@ -10,6 +10,7 @@ use Language::Bel::Types qw(
     is_pair
     is_symbol
     is_symbol_of_name
+    make_char
     make_pair
     make_symbol
 );
@@ -1359,6 +1360,25 @@ my %FASTFUNCS = (
         my $result = SYMBOL_NIL;
         while (@args) {
             $result = make_pair(pop(@args), $result);
+        }
+        return $result;
+    },
+
+    "prs" => sub {
+        my ($call, @args) = @_;
+
+        my @strings;
+        for (@args) {
+            push(@strings, Language::Bel::Printer::prnice($_));
+        }
+
+        my $result = SYMBOL_NIL;
+        while (@strings) {
+            my $string = pop(@strings);
+            for my $char (reverse(split //, $string)) {
+                my $c = make_char(ord($char));
+                $result = make_pair($c, $result);
+            }
         }
         return $result;
     },

--- a/lib/Language/Bel/Globals/FastFuncs.pm
+++ b/lib/Language/Bel/Globals/FastFuncs.pm
@@ -25,6 +25,7 @@ use Language::Bel::Symbols::Common qw(
     SYMBOL_NIL
     SYMBOL_T
 );
+use Language::Bel::Printer;
 
 use Exporter 'import';
 
@@ -1333,6 +1334,20 @@ my %FASTFUNCS = (
                 SYMBOL_NIL,
             ),
         );
+    },
+
+    "pr" => sub {
+        my ($call, @args) = @_;
+
+        print for
+            map { Language::Bel::Printer::prnice($_) }
+            @args;
+
+        my $result = SYMBOL_NIL;
+        while (@args) {
+            $result = make_pair(pop(@args), $result);
+        }
+        return $result;
     },
 );
 

--- a/lib/Language/Bel/Globals/Source.pm
+++ b/lib/Language/Bel/Globals/Source.pm
@@ -905,7 +905,10 @@ __DATA__
 
 ; skip prelts
 
-; skip prn
+(def prn args
+  (map [do (print _) (prc \sp)] args)
+  (prc \lf)
+  (last args))
 
 (def pr args
   (map prnice args))

--- a/lib/Language/Bel/Globals/Source.pm
+++ b/lib/Language/Bel/Globals/Source.pm
@@ -1139,7 +1139,8 @@ __DATA__
        (bind outs ,v ,@body)
        (car ,v))))
 
-; skip prs
+(def prs args
+  (record (apply pr args)))
 
 (def array (dims (o default))
   (if (no dims)

--- a/lib/Language/Bel/Globals/Source.pm
+++ b/lib/Language/Bel/Globals/Source.pm
@@ -907,7 +907,8 @@ __DATA__
 
 ; skip prn
 
-; skip pr
+(def pr args
+  (map prnice args))
 
 ; skip prnice
 

--- a/lib/Language/Bel/Printer.pm
+++ b/lib/Language/Bel/Printer.pm
@@ -79,7 +79,50 @@ sub _print {
         return join("", @fragments);
     }
     else {
-        die "unhandled: not a symbol";
+        die "unhandled: unknown thing to print";
+    }
+}
+
+sub prnice {
+    my ($ast) = @_;
+
+    my $r_i;
+    if (is_symbol($ast)) {
+        my $name = symbol_name($ast);
+        return $name;
+    }
+    elsif (is_char($ast)) {
+        my $codepoint = char_codepoint($ast);
+        return chr($codepoint);
+    }
+    elsif (is_string($ast)) {
+        return string_value($ast);
+    }
+    elsif ($r_i = is_number($ast)) {
+        my $r = $r_i->[0];
+        my $i = $r_i->[1];
+        return prnum($r, $i);
+    }
+    elsif (is_pair($ast)) {
+        my @fragments = ("(");
+        my $first_elem = 1;
+        while (is_pair($ast) && !is_number($ast)) {
+            if (!$first_elem) {
+                push @fragments, " ";
+            }
+            push @fragments, _print(pair_car($ast));
+            $ast = pair_cdr($ast);
+            $first_elem = "";
+        }
+        if (!is_nil($ast)) {
+            push @fragments, " . ";
+            push @fragments, _print($ast);
+        }
+        push @fragments, ")";
+        return join("", @fragments);
+    }
+    else {
+        die "unhandled: unknown thing to print";
     }
 }
 
@@ -213,6 +256,7 @@ sub prnum {
 
 our @EXPORT_OK = qw(
     _print
+    prnice
 );
 
 1;


### PR DESCRIPTION
This can make quite a difference when running scripts (#100). Even though this is quite fake &mdash; as in, the printer is Perl-provided instead of Bel-provided &mdash; it's still an improvement over no printer.

For example in #115, this would check off the "`prs` and `prn`" box even though neither of the two sub-boxes would be checked yet.

<del>Although I see now that I need to do `prs` as well. Will do that now.</del> Done.