### PR TITLE
Enrich the "count implemented globals" with information about what features we're waiting for

### DIFF
--- a/lib/Language/Bel/Expander/Bquote.pm
+++ b/lib/Language/Bel/Expander/Bquote.pm
@@ -27,7 +27,7 @@ sub _bqexpand {
         my $cdr_ast = pair_cdr($ast);
 
         if (is_symbol_of_name($car_ast, "bquote")) {
-            die "bquote of nothing"
+            return $ast
                 unless is_pair($cdr_ast);
             return bquote(pair_car($cdr_ast));
         }

--- a/lib/Language/Bel/Globals/Source.pm
+++ b/lib/Language/Bel/Globals/Source.pm
@@ -101,7 +101,7 @@ __DATA__
 
 (def char   (x) (= (type x) 'char))
 
-; skip stream
+; skip stream [waiting for streams]
 
 (def proper (x)
   (or (no x)
@@ -200,11 +200,11 @@ __DATA__
 (def is (x)
   [= _ x])
 
-; skip eif
+; skip eif [waiting for ccc]
 
-; skip onerr
+; skip onerr [waiting for ccc]
 
-; skip safe
+; skip safe [waiting for ccc]
 
 (def literal (e)
   (or (in e t nil o apply)
@@ -220,65 +220,65 @@ __DATA__
 (def isa (name)
   [begins _ `(lit ,name) id])
 
-; skip bel
+; skip bel [waiting for evaluator]
 
-; skip mev
+; skip mev [waiting for evaluator]
 
-; skip sched
+; skip sched [waiting for evaluator]
 
-; skip ev
+; skip ev [waiting for evaluator]
 
-; skip vref
+; skip vref [waiting for evaluator]
 
-; skip smark
+; skip smark [waiting for evaluator]
 
-; skip inwhere
+; skip inwhere [waiting for evaluator]
 
-; skip lookup
+; skip lookup [waiting for evaluator]
 
-; skip binding
+; skip binding [waiting for evaluator]
 
-; skip sigerr
+; skip sigerr [waiting for evaluator]
 
-; skip fu
+; skip fu [waiting for evaluator]
 
-; skip evmark
+; skip evmark [waiting for evaluator]
 
-; skip forms
+; skip forms [waiting for evaluator]
 
-; skip form
+; skip form [waiting for evaluator]
 
-; skip formfn
+; skip formfn [waiting for evaluator]
 
-; skip parameters
+; skip parameters [waiting for evaluator]
 
-; skip quote
+; skip quote [waiting for evaluator]
 
-; skip if
+; skip if [waiting for evaluator]
 
-; skip if2
+; skip if2 [waiting for evaluator]
 
-; skip where
+; skip where [waiting for evaluator]
 
-; skip dyn
+; skip dyn [waiting for evaluator]
 
-; skip dyn2
+; skip dyn2 [waiting for evaluator]
 
-; skip after
+; skip after [waiting for evaluator]
 
-; skip ccc
+; skip ccc [waiting for evaluator]
 
-; skip thread
+; skip thread [waiting for evaluator]
 
-; skip evcall
+; skip evcall [waiting for evaluator]
 
-; skip evcall2
+; skip evcall2 [waiting for evaluator]
 
-; skip applym
+; skip applym [waiting for evaluator]
 
-; skip applyf
+; skip applyf [waiting for evaluator]
 
-; skip applylit
+; skip applylit [waiting for evaluator]
 
 (set virfns nil)
 
@@ -296,29 +296,29 @@ __DATA__
 (loc (is cdr) (f args a s r m)
   (mev (cdr s) (cons (list (car args) 'd) r) m))
 
-; skip okenv
+; skip okenv [waiting for evaluator]
 
-; skip okstack
+; skip okstack [waiting for evaluator]
 
-; skip okparms
+; skip okparms [waiting for evaluator]
 
-; skip oktoparm
+; skip oktoparm [waiting for evaluator]
 
-; skip prims
+; skip prims [waiting for evaluator]
 
-; skip applyprim
+; skip applyprim [waiting for evaluator]
 
-; skip applyclo
+; skip applyclo [waiting for evaluator]
 
-; skip pass
+; skip pass [waiting for evaluator]
 
-; skip typecheck
+; skip typecheck [waiting for evaluator]
 
-; skip destructure
+; skip destructure [waiting for evaluator]
 
-; skip applycont
+; skip applycont [waiting for evaluator]
 
-; skip protected
+; skip protected [waiting for evaluator]
 
 (def function (x)
   (find [(isa _) x] '(prim clo)))
@@ -750,121 +750,121 @@ __DATA__
     `(let ,v ,x
        (zap [rem ,v _ ,@rest] ,place))))
 
-; skip cbuf
+; skip cbuf [waiting for streams]
 
-; skip open
+; skip open [waiting for streams]
 
-; skip close
+; skip close [waiting for streams]
 
-; skip peek
+; skip peek [waiting for streams]
 
-; skip rdc
+; skip rdc [waiting for streams]
 
-; skip bbuf
+; skip bbuf [waiting for streams]
 
-; skip bitc
+; skip bitc [waiting for streams]
 
-; skip digit
+; skip digit [waiting for streams]
 
-; skip breakc
+; skip breakc [waiting for streams]
 
-; skip signc
+; skip signc [waiting for streams]
 
-; skip intrac
+; skip intrac [waiting for streams]
 
-; skip source
+; skip source [waiting for streams]
 
-; skip read
+; skip read [waiting for reader]
 
-; skip saferead
+; skip saferead [waiting for reader]
 
-; skip rdex
+; skip rdex [waiting for reader]
 
-; skip eatwhite
+; skip eatwhite [waiting for reader]
 
-; skip charstil
+; skip charstil [waiting for reader]
 
-; skip syntax
+; skip syntax [waiting for reader]
 
-; skip syn
+; skip syn [waiting for reader]
 
-; skip \(
+; skip \( [waiting for reader]
 
-; skip \)
+; skip \) [waiting for reader]
 
-; skip \[
+; skip \[ [waiting for reader]
 
-; skip \]
+; skip \] [waiting for reader]
 
-; skip rdlist
+; skip rdlist [waiting for reader]
 
-; skip rddot
+; skip rddot [waiting for reader]
 
-; skip hard-rdex
+; skip hard-rdex [waiting for reader]
 
-; skip namecs
+; skip namecs [waiting for reader]
 
-; skip \\
+; skip \\ [waiting for reader]
 
-; skip \'
+; skip \' [waiting for reader]
 
-; skip \`
+; skip \` [waiting for reader]
 
-; skip \,
+; skip \, [waiting for reader]
 
-; skip rdwrap
+; skip rdwrap [waiting for reader]
 
-; skip \"
+; skip \" [waiting for reader]
 
-; skip \¦
+; skip \¦ [waiting for reader]
 
-; skip rddelim
+; skip rddelim [waiting for reader]
 
-; skip \#
+; skip \# [waiting for reader]
 
-; skip rdtarget
+; skip rdtarget [waiting for reader]
 
-; skip rdword
+; skip rdword [waiting for reader]
 
-; skip parseword
+; skip parseword [waiting for reader]
 
-; skip parsenum
+; skip parsenum [waiting for reader]
 
-; skip validi
+; skip validi [waiting for reader]
 
-; skip validr
+; skip validr [waiting for reader]
 
-; skip validd
+; skip validd [waiting for reader]
 
-; skip parsei
+; skip parsei [waiting for reader]
 
-; skip parsesr
+; skip parsesr [waiting for reader]
 
-; skip parsed
+; skip parsed [waiting for reader]
 
-; skip parseint
+; skip parseint [waiting for reader]
 
-; skip charint
+; skip charint [waiting for reader]
 
-; skip parset
+; skip parset [waiting for reader]
 
-; skip parseslist
+; skip parseslist [waiting for reader]
 
-; skip parsecom
+; skip parsecom [waiting for reader]
 
-; skip parseno
+; skip parseno [waiting for reader]
 
-; skip bquote
+; skip bquote [waiting for backquotes]
 
-; skip bqex
+; skip bqex [waiting for backquotes]
 
-; skip bqthru
+; skip bqthru [waiting for backquotes]
 
-; skip bqexpair
+; skip bqexpair [waiting for backquotes]
 
-; skip spa
+; skip spa [waiting for backquotes]
 
-; skip spd
+; skip spd [waiting for backquotes]
 
 (mac comma args
   '(err 'comma-outside-backquote))
@@ -875,35 +875,35 @@ __DATA__
 (mac splice args
   '(err 'comma-at-outside-list))
 
-; skip print
+; skip print [waiting for printer]
 
-; skip namedups
+; skip namedups [waiting for printer]
 
-; skip cells
+; skip cells [waiting for printer]
 
-; skip prc
+; skip prc [waiting for printer]
 
-; skip ustring
+; skip ustring [waiting for printer]
 
-; skip prstring
+; skip prstring [waiting for printer]
 
-; skip presc
+; skip presc [waiting for printer]
 
-; skip prsimple
+; skip prsimple [waiting for printer]
 
-; skip prsymbol
+; skip prsymbol [waiting for printer]
 
-; skip prnum
+; skip prnum [waiting for printer]
 
-; skip rrep
+; skip rrep [waiting for printer]
 
-; skip irep
+; skip irep [waiting for printer]
 
-; skip intchar
+; skip intchar [waiting for printer]
 
-; skip prpair
+; skip prpair [waiting for printer]
 
-; skip prelts
+; skip prelts [waiting for printer]
 
 (def prn args
   (map [do (print _) (prc \sp)] args)
@@ -913,7 +913,7 @@ __DATA__
 (def pr args
   (map prnice args))
 
-; skip prnice
+; skip prnice [waiting for printer]
 
 (def drop (n|whole xs)
   (if (= n 0)
@@ -928,7 +928,7 @@ __DATA__
 (vir num (f args)
   `(nth ,f ,@args))
 
-; skip nchar
+; skip nchar [waiting for chars]
 
 (def first (n|whole xs)
   (if (or (= n 0) (no xs))
@@ -936,7 +936,7 @@ __DATA__
       (cons (car xs)
             (first (- n 1) (cdr xs)))))
 
-; skip catch
+; skip catch [waiting for ccc]
 
 (def cut (xs (o start 1) (o end (len xs)))
   (first (- (+ end 1 (if (< end 0) (len xs) 0))
@@ -1123,15 +1123,15 @@ __DATA__
                  f)))
     (if (< n 0) (-:r:- n) (r n))))
 
-; skip withfile
+; skip withfile [waiting for streams]
 
-; skip from
+; skip from [waiting for streams]
 
-; skip to
+; skip to [waiting for streams]
 
-; skip readall
+; skip readall [waiting for streams]
 
-; skip load
+; skip load [waiting for streams, evaluator]
 
 (mac record body
   (letu v
@@ -1200,6 +1200,6 @@ __DATA__
                    it))
        (err 'no-template)))
 
-; skip readas
+; skip readas [waiting for evaluator]
 
 (def err args)

--- a/lib/Language/Bel/NotYetImplemented.pm
+++ b/lib/Language/Bel/NotYetImplemented.pm
@@ -1,0 +1,25 @@
+package Language::Bel::NotYetImplemented;
+
+use 5.006;
+use strict;
+use warnings;
+
+use Exporter 'import';
+
+sub list {
+    return (
+        chars => 1,
+        ccc => 1,
+        backquotes => 1,
+        printer => 1,
+        streams => 1,
+        reader => 1,
+        evaluator => 1,
+    );
+}
+
+our @EXPORT_OK = qw(
+    list
+);
+
+1;

--- a/lib/Language/Bel/NotYetImplemented.pm
+++ b/lib/Language/Bel/NotYetImplemented.pm
@@ -8,13 +8,41 @@ use Exporter 'import';
 
 sub list {
     return (
-        chars => 1,
-        ccc => 1,
-        backquotes => 1,
-        printer => 1,
-        streams => 1,
-        reader => 1,
-        evaluator => 1,
+        chars => [
+            "(nchar 65)",
+            "\\A",
+            "('unboundb nchar)",
+        ],
+        ccc => [
+            "(list 'a (ccc (fn (c) 'b)))",
+            "(a b)",
+            "('unboundb ccc)",
+        ],
+        backquotes => [
+            "(isa!mac bquote)",
+            "t",
+            "('unboundb bquote)",
+        ],
+        printer => [
+            "(function print)",
+            "clo",
+            "('unboundb print)",
+        ],
+        streams => [
+            "(function stream)",
+            "clo",
+            "('unboundb stream)",
+        ],
+        reader => [
+            q[(read '("[cons _ 'b]"))],
+            "(fn (_) (cons _ 'b))",
+            "('unboundb read)",
+        ],
+        evaluator => [
+            "(bel 'hi)",
+            "hi",
+            "('unboundb bel)",
+        ],
     );
 }
 

--- a/t/implemented-globals.t
+++ b/t/implemented-globals.t
@@ -4,17 +4,11 @@ use strict;
 use warnings;
 use Test::More;
 
+use Language::Bel::NotYetImplemented;
+
 plan tests => 3;
 
-my %listed = (
-    chars => 1,
-    ccc => 1,
-    backquotes => 1,
-    printer => 1,
-    streams => 1,
-    reader => 1,
-    evaluator => 1,
-);
+my %listed = Language::Bel::NotYetImplemented::list();
 my %waiting_for;
 
 sub set_difference {

--- a/t/implemented-globals.t
+++ b/t/implemented-globals.t
@@ -4,7 +4,30 @@ use strict;
 use warnings;
 use Test::More;
 
-plan tests => 1;
+plan tests => 3;
+
+my %listed = (
+    chars => 1,
+    ccc => 1,
+    backquotes => 1,
+    printer => 1,
+    streams => 1,
+    reader => 1,
+    evaluator => 1,
+);
+my %waiting_for;
+
+sub set_difference {
+    my ($h1_ref, $h2_ref) = @_;
+
+    my %difference;
+    for my $k (keys(%$h1_ref)) {
+        if (!exists $h2_ref->{$k}) {
+            $difference{$k}++;
+        }
+    }
+    return keys(%difference);
+}
 
 my $bel_bel_file = "pg/bel.bel";
 open my $BEL_BEL, "<", $bel_bel_file
@@ -77,8 +100,11 @@ while ($i < @bel_globals && !eof($SOURCE)) {
     if ($source_definition eq $bel_global) {
         $num_implemented++;
     }
-    elsif ($source_definition eq $skip_decl) {
-        # we are allowing this one to be skipped
+    elsif ($source_definition =~ /^; skip \Q$name\E \[waiting for (\w+(?:, \w+)*)\]$/) {
+        my $features = $1;
+        for my $feature (split /, /, $features) {
+            $waiting_for{$feature}++;
+        }
     }
     elsif ($name eq "randlen") {
         # make a special exception for `randlen`, which wants `read`
@@ -120,3 +146,18 @@ is $number_in_readme,
     $num_implemented,
     "the README.md file correctly reports the number of implemented globals";
 
+{
+    my $waiting_for_but_not_listed = join ", ", set_difference(\%waiting_for, \%listed);
+
+    is $waiting_for_but_not_listed,
+        "",
+        "all the features we're waiting for are listed";
+}
+
+{
+    my $listed_but_not_waiting_for = join ", ", set_difference(\%listed, \%waiting_for);
+
+    is $listed_but_not_waiting_for,
+        "",
+        "all the listed features are things we're waiting for";
+}

--- a/t/not-yet-implemented.t
+++ b/t/not-yet-implemented.t
@@ -1,0 +1,19 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings;
+use Test::More;
+
+use Language::Bel::Test;
+use Language::Bel::NotYetImplemented;
+
+my %list = Language::Bel::NotYetImplemented::list();
+
+plan tests => scalar(keys(%list));
+
+for my $feature (sort(keys(%list))) {
+    my $todo_tuple = $list{$feature};
+    my ($input, $expected_future_output, $expected_error) = @$todo_tuple;
+
+    bel_todo($input, $expected_future_output, $expected_error);
+}


### PR DESCRIPTION
...up to and including to-do tests to double-check that we don't actually have those feature yet.

In other words, we're populating the test suite with ticking time bombs to remind us when we actually acquire those feature we say we don't yet have. That's a good thing &mdash; it ensures consistency.