### PR TITLE
Add threads among not-yet-implemented

### DIFF
--- a/lib/Language/Bel/NotYetImplemented.pm
+++ b/lib/Language/Bel/NotYetImplemented.pm
@@ -18,6 +18,11 @@ sub list {
             "(a b)",
             "('unboundb ccc)",
         ],
+        thread => [
+            "(thread (+ 2 2))",
+            "4",
+            "('unboundb thread)",
+        ],
         backquotes => [
             "(isa!mac bquote)",
             "t",

--- a/t/implemented-globals.t
+++ b/t/implemented-globals.t
@@ -6,7 +6,7 @@ use Test::More;
 
 use Language::Bel::NotYetImplemented;
 
-plan tests => 4;
+plan tests => 3;
 
 my %listed = Language::Bel::NotYetImplemented::list();
 my %waiting_for;
@@ -160,12 +160,4 @@ is $second_number_in_readme,
     is $waiting_for_but_not_listed,
         "",
         "all the features we're waiting for are listed";
-}
-
-{
-    my $listed_but_not_waiting_for = join ", ", set_difference(\%listed, \%waiting_for);
-
-    is $listed_but_not_waiting_for,
-        "",
-        "all the listed features are things we're waiting for";
 }


### PR DESCRIPTION
As part of this, also _remove_ the test that says that each NYI feature must be waited for by some unimplemented global. This is not the case for threads; threads are occasionally useful but they are not used by any of the globals.