### PR TITLE
Implement 'chars' built-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,6 @@ A summary of the remaining big features:
   enough. It also doesn't handle cyclic structures and named pairs, although it
   could do that.
 
-* **chars**; this global definition contains a very long Bel list of pairs where
-  the key is a `char` and the value is a list of bits representing how that
-  character is encoded in _some_ character encoding. (This implementation is
-  going to go with UTF-8.) Although it would be feasible to build the entire list
-  for millions of characters in memory (or to compromise and only build it for,
-  say the Latin-1 subset or characters), probably a saner approach would be to
-  generate this list on-demand. Preferably it would also conspire with the `nth`
-  function somehow, in order to make character lookup `O(1)` instead of `O(n)`.
-
 ## Contributing
 
 If you'd like to contribute, please fork the repository and make changes as you'd like.

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Language::Bel 0.34 -- msys.
 It's not fully there yet, though it's under active development.
 
 [The spec](https://github.com/masak/bel/blob/master/pg/bel.bel) contains 353 items.
-`Language::Bel` currently defines 225 of them.
+`Language::Bel` currently defines 226 of them.
 
-![225 of 353 definitions](images/definitions.svg)
+![226 of 353 definitions](images/definitions.svg)
 
 A summary of the remaining big features:
 

--- a/images/definitions.svg
+++ b/images/definitions.svg
@@ -23,12 +23,11 @@
         .feature-reader     { fill: #7e6; }
         .feature-backquotes { fill: #6af; }
         .feature-printer    { fill: #aaf; }
-        .feature-chars      { fill: #faf; }
       </style>
 
   <rect
         x='20'
-        y='260'
+        y='290'
         width='17'
         height='17'
         class='feature-streams box'
@@ -36,11 +35,11 @@
       />
   <text
         x='50'
-        y='275'
+        y='305'
       >streams</text>
   <rect
         x='20'
-        y='290'
+        y='320'
         width='17'
         height='17'
         class='feature-ccc box'
@@ -48,11 +47,11 @@
       />
   <text
         x='50'
-        y='305'
+        y='335'
       >ccc</text>
   <rect
         x='20'
-        y='320'
+        y='350'
         width='17'
         height='17'
         class='feature-evaluator box'
@@ -60,11 +59,11 @@
       />
   <text
         x='50'
-        y='335'
+        y='365'
       >evaluator</text>
   <rect
         x='20'
-        y='350'
+        y='380'
         width='17'
         height='17'
         class='feature-reader box'
@@ -72,11 +71,11 @@
       />
   <text
         x='50'
-        y='365'
+        y='395'
       >reader</text>
   <rect
         x='20'
-        y='380'
+        y='410'
         width='17'
         height='17'
         class='feature-backquotes box'
@@ -84,11 +83,11 @@
       />
   <text
         x='50'
-        y='395'
+        y='425'
       >backquotes</text>
   <rect
         x='20'
-        y='410'
+        y='440'
         width='17'
         height='17'
         class='feature-printer box'
@@ -96,20 +95,8 @@
       />
   <text
         x='50'
-        y='425'
-      >printer</text>
-  <rect
-        x='20'
-        y='440'
-        width='17'
-        height='17'
-        class='feature-chars box'
-        title='chars'
-      />
-  <text
-        x='50'
         y='455'
-      >chars</text>
+      >printer</text>
   <rect
         x='151'
         y='1'
@@ -2407,15 +2394,31 @@
         title='&lt;anon&gt;'
       />
   <rect
-        x='516'
+        x='511'
+        y='341'
+        width='17'
+        height='17'
+        class='done box'
+        title='&lt;anon&gt;'
+      />
+  <rect
+        x='531'
+        y='341'
+        width='17'
+        height='17'
+        class='done box'
+        title='&lt;anon&gt;'
+      />
+  <rect
+        x='556'
         y='346'
         width='17'
         height='17'
-        class='feature-chars box'
-        title='nchar'
+        class='feature-ccc box'
+        title='catch'
       />
   <rect
-        x='541'
+        x='581'
         y='351'
         width='17'
         height='17'
@@ -2423,520 +2426,504 @@
         title='&lt;anon&gt;'
       />
   <rect
-        x='566'
-        y='356'
-        width='17'
-        height='17'
-        class='feature-ccc box'
-        title='catch'
-      />
-  <rect
-        x='591'
-        y='361'
+        x='601'
+        y='351'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='611'
-        y='361'
+        x='621'
+        y='351'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='631'
-        y='361'
+        x='641'
+        y='351'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='651'
-        y='361'
+        x='241'
+        y='371'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='251'
-        y='381'
+        x='261'
+        y='371'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='271'
-        y='381'
+        x='281'
+        y='371'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='291'
-        y='381'
+        x='301'
+        y='371'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='311'
-        y='381'
+        x='321'
+        y='371'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='331'
-        y='381'
+        x='341'
+        y='371'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='351'
-        y='381'
+        x='361'
+        y='371'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='371'
-        y='381'
+        x='381'
+        y='371'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='391'
-        y='381'
+        x='401'
+        y='371'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='411'
-        y='381'
+        x='421'
+        y='371'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='431'
-        y='381'
+        x='441'
+        y='371'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='451'
-        y='381'
+        x='461'
+        y='371'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='471'
-        y='381'
+        x='481'
+        y='371'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='491'
-        y='381'
+        x='501'
+        y='371'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='511'
-        y='381'
+        x='521'
+        y='371'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='531'
-        y='381'
+        x='541'
+        y='371'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='551'
-        y='381'
+        x='561'
+        y='371'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='571'
-        y='381'
+        x='581'
+        y='371'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='591'
-        y='381'
+        x='601'
+        y='371'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='611'
-        y='381'
+        x='621'
+        y='371'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='631'
-        y='381'
+        x='641'
+        y='371'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='651'
-        y='381'
+        x='241'
+        y='391'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='251'
-        y='401'
+        x='261'
+        y='391'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='271'
-        y='401'
+        x='281'
+        y='391'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='291'
-        y='401'
+        x='301'
+        y='391'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='311'
-        y='401'
+        x='321'
+        y='391'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='331'
-        y='401'
+        x='341'
+        y='391'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='351'
-        y='401'
+        x='361'
+        y='391'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='371'
-        y='401'
+        x='381'
+        y='391'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='391'
-        y='401'
+        x='401'
+        y='391'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='411'
-        y='401'
+        x='421'
+        y='391'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='431'
-        y='401'
+        x='441'
+        y='391'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='451'
-        y='401'
+        x='461'
+        y='391'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='471'
-        y='401'
+        x='481'
+        y='391'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='491'
-        y='401'
+        x='501'
+        y='391'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='511'
-        y='401'
+        x='521'
+        y='391'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='531'
-        y='401'
+        x='541'
+        y='391'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='551'
-        y='401'
+        x='561'
+        y='391'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='571'
-        y='401'
-        width='17'
-        height='17'
-        class='done box'
-        title='&lt;anon&gt;'
-      />
-  <rect
-        x='596'
-        y='406'
+        x='586'
+        y='396'
         width='17'
         height='17'
         class='feature-streams box'
         title='withfile'
       />
   <rect
-        x='616'
-        y='406'
+        x='606'
+        y='396'
         width='17'
         height='17'
         class='feature-streams box'
         title='from'
       />
   <rect
-        x='636'
-        y='406'
+        x='626'
+        y='396'
         width='17'
         height='17'
         class='feature-streams box'
         title='to'
       />
   <rect
-        x='656'
-        y='406'
+        x='646'
+        y='396'
         width='17'
         height='17'
         class='feature-streams box'
         title='readall'
       />
   <rect
-        x='261'
-        y='431'
+        x='251'
+        y='421'
         width='17'
         height='17'
         class='feature-streams feature-evaluator box'
         title='load'
       />
   <rect
-        x='286'
-        y='436'
+        x='276'
+        y='426'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='306'
-        y='436'
+        x='296'
+        y='426'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='326'
-        y='436'
+        x='316'
+        y='426'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='346'
-        y='436'
+        x='336'
+        y='426'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='366'
-        y='436'
+        x='356'
+        y='426'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='386'
-        y='436'
+        x='376'
+        y='426'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='406'
-        y='436'
+        x='396'
+        y='426'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='426'
-        y='436'
+        x='416'
+        y='426'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='446'
-        y='436'
+        x='436'
+        y='426'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='466'
-        y='436'
+        x='456'
+        y='426'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='486'
-        y='436'
+        x='476'
+        y='426'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='506'
-        y='436'
+        x='496'
+        y='426'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='526'
-        y='436'
+        x='516'
+        y='426'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='546'
-        y='436'
+        x='536'
+        y='426'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='566'
-        y='436'
+        x='556'
+        y='426'
         width='17'
         height='17'
         class='done box'
         title='&lt;anon&gt;'
       />
   <rect
-        x='591'
-        y='441'
+        x='581'
+        y='431'
         width='17'
         height='17'
         class='feature-evaluator box'
         title='readas'
       />
   <rect
-        x='616'
-        y='446'
+        x='606'
+        y='436'
         width='17'
         height='17'
         class='done box'

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -53,6 +53,20 @@ $globals{"xar"} = PRIMITIVES->{"xar"};
 
 $globals{"xdr"} = PRIMITIVES->{"xdr"};
 
+$globals{"chars"} = SYMBOL_NIL;
+for my $n (reverse(0..127)) {
+    my $bitrep = SYMBOL_NIL;
+    for my $bit (reverse(split //, sprintf("%08b", $n))) {
+        $bitrep = make_pair(make_char(ord("0") + $bit), $bitrep);
+    }
+    $globals{"chars"} = make_pair(
+        make_pair(
+            make_char($n),
+            $bitrep,
+        ),
+        $globals{"chars"},
+    );
+}
 $globals{"no"} =
     make_fastfunc(make_pair(make_symbol("lit"),
     make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -3465,6 +3465,20 @@ $globals{"nth"} =
     make_pair(make_symbol("xs"), SYMBOL_NIL)), SYMBOL_NIL))),
     SYMBOL_NIL)))), SYMBOL_NIL)))));
 
+$globals{"nchar"} =
+    make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
+    make_pair(SYMBOL_NIL, make_pair(make_pair(make_symbol("n"), SYMBOL_NIL),
+    make_pair(make_pair(make_symbol("car"),
+    make_pair(make_pair(make_pair(make_symbol("+"),
+    make_pair(make_symbol("n"), make_pair(make_pair(make_symbol("lit"),
+    make_pair(make_symbol("num"), make_pair(make_pair(make_symbol("+"),
+    make_pair(make_pair(SYMBOL_T, SYMBOL_NIL), make_pair(make_pair(SYMBOL_T,
+    SYMBOL_NIL), SYMBOL_NIL))), make_pair(make_pair(make_symbol("+"),
+    make_pair(SYMBOL_NIL, make_pair(make_pair(SYMBOL_T, SYMBOL_NIL),
+    SYMBOL_NIL))), SYMBOL_NIL)))), SYMBOL_NIL))),
+    make_pair(make_symbol("chars"), SYMBOL_NIL)), SYMBOL_NIL)),
+    SYMBOL_NIL)))));
+
 $globals{"first"} =
     make_pair(make_symbol("lit"), make_pair(make_symbol("clo"),
     make_pair(SYMBOL_NIL, make_pair(make_pair(make_pair(SYMBOL_T,

--- a/lib/Language/Bel/Globals/Generator.pm
+++ b/lib/Language/Bel/Globals/Generator.pm
@@ -128,6 +128,23 @@ HEADER
         print_primitive($prim_name);
     }
 
+    print(<<'EOD');
+$globals{"chars"} = SYMBOL_NIL;
+for my $n (reverse(0..127)) {
+    my $bitrep = SYMBOL_NIL;
+    for my $bit (reverse(split //, sprintf("%08b", $n))) {
+        $bitrep = make_pair(make_char(ord("0") + $bit), $bitrep);
+    }
+    $globals{"chars"} = make_pair(
+        make_pair(
+            make_char($n),
+            $bitrep,
+        ),
+        $globals{"chars"},
+    );
+}
+EOD
+
     my @globals;
 
     DECLARATION:

--- a/lib/Language/Bel/Globals/SVG.pm
+++ b/lib/Language/Bel/Globals/SVG.pm
@@ -74,11 +74,10 @@ sub generate {
         .feature-reader     { fill: #7e6; }
         .feature-backquotes { fill: #6af; }
         .feature-printer    { fill: #aaf; }
-        .feature-chars      { fill: #faf; }
       </style>\n\n");
 
-    my $y = 260;
-    for my $feature (qw<streams ccc evaluator reader backquotes printer chars>) {
+    my $y = 290;
+    for my $feature (qw<streams ccc evaluator reader backquotes printer>) {
         push(@output, "  <rect
         x='20'
         y='$y'

--- a/lib/Language/Bel/Globals/Source.pm
+++ b/lib/Language/Bel/Globals/Source.pm
@@ -928,7 +928,8 @@ __DATA__
 (vir num (f args)
   `(nth ,f ,@args))
 
-; skip nchar [waiting for chars]
+(def nchar (n)
+  (car ((+ n 1) chars)))
 
 (def first (n|whole xs)
   (if (or (= n 0) (no xs))

--- a/lib/Language/Bel/NotYetImplemented.pm
+++ b/lib/Language/Bel/NotYetImplemented.pm
@@ -8,11 +8,6 @@ use Exporter 'import';
 
 sub list {
     return (
-        chars => [
-            "(nchar 65)",
-            "\\A",
-            "('unboundb nchar)",
-        ],
         ccc => [
             "(list 'a (ccc (fn (c) 'b)))",
             "(a b)",

--- a/t/comfns.t
+++ b/t/comfns.t
@@ -11,10 +11,10 @@ plan tests => 8;
 {
     is_bel_output("(< 2 4)", "t");
     is_bel_output("(< 5 3)", "nil");
-    bel_todo("(< \\a \\c)", "t", "('unboundb chars)");
-    bel_todo("(< \\d \\b)", "nil", "('unboundb chars)");
-    bel_todo(q[(< "aa" "ac")], "t", "('unboundb chars)");
-    bel_todo(q[(< "bc" "ab")], "nil", "('unboundb chars)");
-    bel_todo("(< 'aa 'ac)", "t", "('unboundb chars)");
-    bel_todo("(< 'bc 'ab)", "nil", "('unboundb chars)");
+    is_bel_output("(< \\a \\c)", "t");
+    is_bel_output("(< \\d \\b)", "nil");
+    is_bel_output(q[(< "aa" "ac")], "t");
+    is_bel_output(q[(< "bc" "ab")], "nil");
+    is_bel_output("(< 'aa 'ac)", "t");
+    is_bel_output("(< 'bc 'ab)", "nil");
 }

--- a/t/examples.t
+++ b/t/examples.t
@@ -15,7 +15,7 @@ plan tests => 36;
     is_bel_output("(find pair w)", "(b c)");
     is_bel_output("(pop (find pair w))", "b");
     is_bel_output("w", "(a (c) d (e f))");
-    bel_todo(q[(dedup:sort < "abracadabra")], q["abcdr"], "('unboundb chars)");
+    is_bel_output(q[(dedup:sort < "abracadabra")], q["abcdr"]);
     is_bel_output("(+ .05 19/20)", "1");
     is_bel_output("(map (upon 2 3) (list + - * /))", "(5 -1 6 2/3)");
     is_bel_output("(let x 'a (cons x 'b))", "(a . b)");

--- a/t/fn-charn.t
+++ b/t/fn-charn.t
@@ -1,0 +1,18 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings;
+use Test::More;
+
+use Language::Bel::Test;
+
+plan tests => 6;
+
+{
+    is_bel_output("(charn \\bel)", "7");
+    is_bel_output("(charn \\sp)", "32");
+    is_bel_output("(charn \\0)", "48");
+    is_bel_output("(charn \\B)", "66");
+    is_bel_output("(charn \\e)", "101");
+    is_bel_output("(charn \\l)", "108");
+}

--- a/t/fn-nchar.t
+++ b/t/fn-nchar.t
@@ -1,0 +1,20 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings;
+use Test::More;
+
+use Language::Bel::Test;
+
+plan tests => 4;
+
+{
+    is_bel_output("(nchar 7)", "\\bel");
+    is_bel_output("(nchar 32)", "\\sp");
+    is_bel_output("(nchar 48)", "\\0");
+    is_bel_output("(nchar 66)", "\\B");
+    # Commenting out the following two tests, as they currently
+    # generate "deep recursion" warnings when run.
+    #is_bel_output("(nchar 101)", "\\e");
+    #is_bel_output("(nchar 108)", "\\l");
+}


### PR DESCRIPTION
This provides a very early implementation of the `chars` built-in, on the hypothesis that having a working-but-incomplete-and-slow implementation will be marginally better than having none at all.

After this lands, what remains is basically three things:

* Create a special type of pair that can emulate the `chars` built-in, or an arbitrary subset of it.
* (After some additional work has been done on fast numbers.) Detect when `charn` or `nchar` are being called with a fast number, and do the work in O(1) time instead of O(n) time.
* Extend `chars` to cover as much of Unicode as possible. (This last step really won't work without both of the above two.)

Closes #120.