### PR TITLE
Rework the coin tests

### DIFF
--- a/t/axioms.t
+++ b/t/axioms.t
@@ -64,6 +64,6 @@ plan tests => 39;
 
 {
     is_bel_output("(~~mem (coin) '(t nil))", "t");
-    is_bel_output("(~~mem t (nof 8 (coin)))", "t");
-    is_bel_output("(~~mem nil (nof 8 (coin)))", "t");
+    is_bel_output("(whilet _ (coin))", "nil");
+    is_bel_output("(til _ (coin) no)", "nil");
 }


### PR DESCRIPTION
Funnily enough, the tests become not just more reliable this way, but also much faster on average. (Of course, that big difference in speed shouldn't exist in the first place, but that's another issue.)

Closes #161.