### PR TITLE
Improve mac-record test

### DIFF
--- a/lib/Language/Bel/Test.pm
+++ b/lib/Language/Bel/Test.pm
@@ -56,7 +56,8 @@ sub bel_todo {
                 ? "Expected '$expected_todo_error', got '$error'"
                 : "Expected '$expected_output', got '$actual_output'";
         ok(
-            $error && $error eq $expected_todo_error || !$error && $actual_output ne $expected_output,
+            $expected_todo_error && $error && $error eq $expected_todo_error
+            || !$expected_todo_error && !$error && $actual_output ne $expected_output,
             "TODO $expr ($message)"
         );
     }

--- a/t/02-mac-record.t
+++ b/t/02-mac-record.t
@@ -12,5 +12,5 @@ plan tests => 4;
     is_bel_output("(record (enq \\a outs) (enq \\b outs) (enq \\c outs))", q["abc"]);
     is_bel_output("(record (map [enq _ outs] '(\\x \\y \\z)))", q["xyz"]);
     is_bel_output("(record)", "nil");
-    bel_todo("~~pr", "t", "('unboundb pr)");
+    bel_todo(q[(record (pr (append "# hello" (list \lf))))], q["# hello \n"], "");
 }


### PR DESCRIPTION
The TODO test was succeeding for the wrong reasons. (That one seems to be tricky to get right.)

Replaced the test with another, better TODO test, that checks if `record` manages to capture `pr`.