### PR TITLE
Add 'use 5.006'/'use strict'/'use warnings'

### DIFF
--- a/lib/Language/Bel/LazyGlobal.pm
+++ b/lib/Language/Bel/LazyGlobal.pm
@@ -1,5 +1,9 @@
 package Language::Bel::LazyGlobal;
 
+use 5.006;
+use strict;
+use warnings;
+
 sub new {
     my ($class, $ast) = @_;
 

--- a/lib/Language/Bel/Symbols/Common.pm
+++ b/lib/Language/Bel/Symbols/Common.pm
@@ -1,5 +1,9 @@
 package Language::Bel::Symbols::Common;
 
+use 5.006;
+use strict;
+use warnings;
+
 use Language::Bel::Types qw(make_symbol);
 use Exporter 'import';
 

--- a/lib/Language/Bel/Test.pm
+++ b/lib/Language/Bel/Test.pm
@@ -3,6 +3,7 @@ package Language::Bel::Test;
 use 5.006;
 use strict;
 use warnings;
+
 use Test::More;
 use Language::Bel;
 

--- a/lib/Language/Bel/Type/Char.pm
+++ b/lib/Language/Bel/Type/Char.pm
@@ -1,5 +1,9 @@
 package Language::Bel::Type::Char;
 
+use 5.006;
+use strict;
+use warnings;
+
 sub new {
     my ($class, $codepoint) = @_;
 

--- a/lib/Language/Bel/Type/Pair.pm
+++ b/lib/Language/Bel/Type/Pair.pm
@@ -1,5 +1,9 @@
 package Language::Bel::Type::Pair;
 
+use 5.006;
+use strict;
+use warnings;
+
 sub new {
     my ($class, $car, $cdr) = @_;
 

--- a/lib/Language/Bel/Type/Pair/FastFunc.pm
+++ b/lib/Language/Bel/Type/Pair/FastFunc.pm
@@ -1,6 +1,10 @@
 package Language::Bel::Type::Pair::FastFunc;
 use base qw(Language::Bel::Type::Pair);
 
+use 5.006;
+use strict;
+use warnings;
+
 sub new {
     my ($class, $pair, $fn, $where_fn) = @_;
 

--- a/lib/Language/Bel/Type/Symbol.pm
+++ b/lib/Language/Bel/Type/Symbol.pm
@@ -1,5 +1,9 @@
 package Language::Bel::Type::Symbol;
 
+use 5.006;
+use strict;
+use warnings;
+
 sub new {
     my ($class, $name) = @_;
 

--- a/lib/Language/Bel/Types.pm
+++ b/lib/Language/Bel/Types.pm
@@ -1,5 +1,9 @@
 package Language::Bel::Types;
 
+use 5.006;
+use strict;
+use warnings;
+
 use Language::Bel::Type::Char;
 use Language::Bel::Type::Pair;
 use Language::Bel::Type::Pair::FastFunc;

--- a/t/version-strict-warnings.t
+++ b/t/version-strict-warnings.t
@@ -1,0 +1,89 @@
+use 5.006;
+use strict;
+use warnings;
+
+use Test::More;
+
+plan tests => 3;
+
+sub visit {
+    my ($dir, $fn_ref, $prefix) = @_;
+    $prefix ||= "";
+
+    # un-taint $dir
+    $dir =~ /^(\w+)$/;
+    $dir = $1;
+    chdir($dir);
+
+    for my $file (<*>) {
+        my $name = "$prefix$dir/$file";
+        if ($name =~ /\.pm$/) {
+            $fn_ref->($name, $file);
+        }
+
+        if (-d $file) {
+            visit($file, $fn_ref, "$prefix$dir/");
+        }
+    }
+    chdir("..");
+}
+
+my $no_version = "";
+my $no_strict = "";
+my $no_warnings = "";
+
+sub scan_for_missing_version_strict_warnings {
+    my ($longname, $shortname) = @_;
+
+    open my $fh, "<", $shortname
+        or die "can't open $longname: $!";
+
+    my $this_module_has_version = 0;
+    my $this_module_uses_strict = 0;
+    my $this_module_uses_warnings = 0;
+
+    while (my $line = <$fh>) {
+        $line =~ s/\r?\n$//;
+
+        if ($line eq "use 5.006;") {
+            $this_module_has_version = 1;
+        }
+        elsif ($line eq "use strict;") {
+            $this_module_uses_strict = 1;
+        }
+        elsif ($line eq "use warnings;") {
+            $this_module_uses_warnings = 1;
+        }
+    }
+
+    close $fh;
+
+    if (!$this_module_has_version) {
+        if (!$no_version) {
+            $no_version .= "\n";
+        }
+        $no_version .= "$longname: Missing 'use 5.006;' declaration\n";
+    }
+
+    if (!$this_module_uses_strict) {
+        if (!$no_strict) {
+            $no_strict .= "\n";
+        }
+        $no_strict .= "$longname: Missing 'use strict;' declaration\n";
+    }
+
+    if (!$this_module_uses_warnings) {
+        if (!$no_warnings) {
+            $no_warnings .= "\n";
+        }
+        $no_warnings .= "$longname: Missing 'use warnings;' declaration\n";
+    }
+
+}
+
+visit("lib", \&scan_for_missing_version_strict_warnings);
+
+is $no_version, "", "there are no modules with missing version declarations";
+is $no_strict, "", "there are no modules with missing strict declarations";
+is $no_warnings, "", "there are no modules with missing warnings declarations";
+


### PR DESCRIPTION
To all the .pm modules that didn't have that.

Main reason is that these modules were being mis-classified as
"Raku" by GitHub's heuristic. This should help clear things up.
Also, a good idea in general.

Closes #179. <del>A work in progress because I also promised to add a test.</del> Test added; now ready for prime time!