### PR TITLE
Skip evaluating comments in REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ After downloading Bel, you can run it like this:
 
 ```sh
 $ perl -Ilib bin/bel
-Language::Bel 0.42 -- msys.
+Language::Bel 0.43 -- msys.
 > (+ 2 2)
 4
 > (append "Hello" '(\sp) "world!")

--- a/bin/bel
+++ b/bin/bel
@@ -59,7 +59,7 @@ sub repl {
 
     print("Language::Bel ", $Language::Bel::VERSION, " -- $^O.\n");
     while (defined (my $expr = prompt("> "))) {
-        next if $expr =~ /^\s*$/;
+        next if $expr =~ /^\s*;?/;
 
         eval {
             $b->read_eval_print($expr);

--- a/lib/Language/Bel.pm
+++ b/lib/Language/Bel.pm
@@ -48,11 +48,11 @@ Language::Bel - An interpreter for Paul Graham's language Bel
 
 =head1 VERSION
 
-Version 0.42
+Version 0.43
 
 =cut
 
-our $VERSION = '0.42';
+our $VERSION = '0.43';
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
Used to be only empty lines, but comments also don't need to go through the "REP" part of the REPL.

Closes #230.