### PR TITLE
Always put legend at the bottom of the diagram

### DIFF
--- a/images/definitions.svg
+++ b/images/definitions.svg
@@ -25,78 +25,6 @@
       </style>
 
   <rect
-        x='20'
-        y='225'
-        width='17'
-        height='17'
-        class='done box'
-        title='done'
-      />
-  <text
-        x='50'
-        y='240'
-      >done</text>
-  <rect
-        x='20'
-        y='255'
-        width='17'
-        height='17'
-        class='feature-ccc box'
-        title='ccc'
-      />
-  <text
-        x='50'
-        y='270'
-      >ccc</text>
-  <rect
-        x='20'
-        y='285'
-        width='17'
-        height='17'
-        class='feature-reader box'
-        title='reader'
-      />
-  <text
-        x='50'
-        y='300'
-      >reader</text>
-  <rect
-        x='20'
-        y='315'
-        width='17'
-        height='17'
-        class='feature-backquotes box'
-        title='backquotes'
-      />
-  <text
-        x='50'
-        y='330'
-      >backquotes</text>
-  <rect
-        x='20'
-        y='345'
-        width='17'
-        height='17'
-        class='feature-printer box'
-        title='printer'
-      />
-  <text
-        x='50'
-        y='360'
-      >printer</text>
-  <rect
-        x='20'
-        y='375'
-        width='17'
-        height='17'
-        class='feature-chars box'
-        title='chars'
-      />
-  <text
-        x='50'
-        y='390'
-      >chars</text>
-  <rect
         x='151'
         y='1'
         width='17'
@@ -2928,4 +2856,76 @@
         class='done box'
         title='&lt;anon&gt;'
       />
+  <rect
+        x='20'
+        y='256'
+        width='17'
+        height='17'
+        class='done box'
+        title='done'
+      />
+  <text
+        x='50'
+        y='271'
+      >done</text>
+  <rect
+        x='20'
+        y='286'
+        width='17'
+        height='17'
+        class='feature-ccc box'
+        title='ccc'
+      />
+  <text
+        x='50'
+        y='301'
+      >ccc</text>
+  <rect
+        x='20'
+        y='316'
+        width='17'
+        height='17'
+        class='feature-reader box'
+        title='reader'
+      />
+  <text
+        x='50'
+        y='331'
+      >reader</text>
+  <rect
+        x='20'
+        y='346'
+        width='17'
+        height='17'
+        class='feature-backquotes box'
+        title='backquotes'
+      />
+  <text
+        x='50'
+        y='361'
+      >backquotes</text>
+  <rect
+        x='20'
+        y='376'
+        width='17'
+        height='17'
+        class='feature-printer box'
+        title='printer'
+      />
+  <text
+        x='50'
+        y='391'
+      >printer</text>
+  <rect
+        x='20'
+        y='406'
+        width='17'
+        height='17'
+        class='feature-chars box'
+        title='chars'
+      />
+  <text
+        x='50'
+        y='421'
+      >chars</text>
 </svg>

--- a/lib/Language/Bel/Globals/SVG.pm
+++ b/lib/Language/Bel/Globals/SVG.pm
@@ -80,33 +80,12 @@ sub generate {
         .feature-chars      { fill: #faf; }
       </style>\n\n");
 
-    my $y = 225;
-    my $box_size = 17;
-    for my $feature (qw<done ccc reader backquotes printer chars>) {
-        my $class = $feature eq "done"
-            ? $feature
-            : "feature-$feature";
-        push(@output, "  <rect
-        x='20'
-        y='$y'
-        width='$box_size'
-        height='$box_size'
-        class='$class box'
-        title='$feature'
-      />\n");
-      my $text_y = $y + 15;
-        push(@output, "  <text
-        x='50'
-        y='$text_y'
-      >$feature</text>\n");
-      $y += 30;
-    }
-
     my $x = 0;
-    $y = 0;
+    my $y = 0;
     my $x_offset = 151;
     my $y_offset = 1;
     my $last_features = "+1";
+    my $box_size = 17;
 
     my $max_x = 0;
     my $max_y = 0;
@@ -145,6 +124,28 @@ sub generate {
             ++$y;
         }
         $last_features = $features;
+    }
+
+    my @FEATURES = qw<done ccc reader backquotes printer chars>;
+    $y = $y_offset + 20 * $y - 30 * scalar(@FEATURES);
+    for my $feature (@FEATURES) {
+        my $class = $feature eq "done"
+            ? $feature
+            : "feature-$feature";
+        push(@output, "  <rect
+        x='20'
+        y='$y'
+        width='$box_size'
+        height='$box_size'
+        class='$class box'
+        title='$feature'
+      />\n");
+        my $text_y = $y + 15;
+        push(@output, "  <text
+        x='50'
+        y='$text_y'
+      >$feature</text>\n");
+        $y += 30;
     }
 
     push(@output, "</svg>\n");


### PR DESCRIPTION
It's now computed to always end up bottom-aligned with the bottom row of the main diagram.

This was easier than I thought; it was mostly just a matter of generating the legend after the main diagram.