### PR TITLE
Fix bug in map

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ After downloading Bel, you can run it like this:
 
 ```sh
 $ perl -Ilib bin/bel
-Language::Bel 0.44 -- msys.
+Language::Bel 0.45 -- msys.
 >
 > ;; loops
 > (set n (len (apply append prims)))

--- a/lib/Language/Bel.pm
+++ b/lib/Language/Bel.pm
@@ -48,11 +48,11 @@ Language::Bel - An interpreter for Paul Graham's language Bel
 
 =head1 VERSION
 
-Version 0.44
+Version 0.45
 
 =cut
 
-our $VERSION = '0.44';
+our $VERSION = '0.45';
 
 =head1 SYNOPSIS
 

--- a/lib/Language/Bel/Globals/FastFuncs.pm
+++ b/lib/Language/Bel/Globals/FastFuncs.pm
@@ -180,27 +180,22 @@ sub fastfunc__map {
 
     return SYMBOL_NIL
         unless @ls;
-    my @sublists;
-    my $min_length = -1;
-    for my $list (@ls) {
-        my @sublist;
-        while (!is_nil($list)) {
-            push @sublist, $bel->car($list);
+
+    my @result;
+
+    ELEMENT:
+    while (1) {
+        my @arguments;
+        for my $list (@ls) {
+            last ELEMENT
+                if (is_nil($list));
+
+            push @arguments, $bel->car($list);
             $list = $bel->cdr($list);
         }
-        push @sublists, \@sublist;
-        my $length = scalar(@sublist);
-        $min_length = $min_length == -1 || $length < $min_length
-            ? $length
-            : $min_length;
+        push @result, $bel->{call}->($f, @arguments);
     }
-    my @result;
-    for my $i (0..$min_length-1) {
-        push @result, $bel->{call}->(
-            $f,
-            map { $sublists[$_]->[$i] } 0..$#sublists
-        );
-    }
+
     my $result = SYMBOL_NIL;
     for my $v (reverse(@result)) {
         $result = make_pair($v, $result);

--- a/t/fn-map.t
+++ b/t/fn-map.t
@@ -6,11 +6,12 @@ use Test::More;
 
 use Language::Bel::Test;
 
-plan tests => 4;
+plan tests => 5;
 
 {
     is_bel_output("(map car '((a b) (c d) (e f)))", "(a c e)");
     is_bel_output("(map cons '(a b c) '(1 2 3))", "((a . 1) (b . 2) (c . 3))");
     is_bel_output("(map cons '(a b c) '(1 2))", "((a . 1) (b . 2))");
     is_bel_output("(map join)", "nil");
+    is_bel_output("(map list '(1 2) '(a b . c))", "((1 a) (2 b))");
 }


### PR DESCRIPTION
Used to be Bel wrongly gave a car-on-atom error if it happened after
the shortest list had ended. This is now fixed.

Closes #212.