### PR TITLE
Do all pair access through methods

### DIFF
--- a/lib/Language/Bel/Type/Pair.pm
+++ b/lib/Language/Bel/Type/Pair.pm
@@ -11,4 +11,28 @@ sub new {
     return bless($obj, $class);
 }
 
+sub car {
+    my ($self) = @_;
+
+    return $self->{car};
+}
+
+sub cdr {
+    my ($self) = @_;
+
+    return $self->{cdr};
+}
+
+sub xar {
+    my ($self, $car) = @_;
+
+    return $self->{car} = $car;
+}
+
+sub xdr {
+    my ($self, $cdr) = @_;
+
+    return $self->{cdr} = $cdr;
+}
+
 1;

--- a/lib/Language/Bel/Type/Pair/FastFunc.pm
+++ b/lib/Language/Bel/Type/Pair/FastFunc.pm
@@ -9,12 +9,35 @@ sub new {
     my ($class, $pair, $fn, $where_fn) = @_;
 
     my $obj = {
-        car => $pair->{car},
-        cdr => $pair->{cdr},
+        pair => $pair,
         fn => $fn,
         where_fn => $where_fn,
     };
     return bless($obj, $class);
+}
+
+sub car {
+    my ($self) = @_;
+
+    return $self->{pair}->car();
+}
+
+sub cdr {
+    my ($self) = @_;
+
+    return $self->{pair}->cdr();
+}
+
+sub xar {
+    my ($self, $car) = @_;
+
+    return $self->{pair}->xar($car);
+}
+
+sub xdr {
+    my ($self, $cdr) = @_;
+
+    return $self->{pair}->xdr($cdr);
 }
 
 sub handles_where {

--- a/lib/Language/Bel/Types.pm
+++ b/lib/Language/Bel/Types.pm
@@ -135,26 +135,26 @@ sub make_symbol {
 sub pair_car {
     my ($pair) = @_;
 
-    return $pair->{car};
+    return $pair->car();
 }
 
 sub pair_cdr {
     my ($pair) = @_;
 
-    return $pair->{cdr};
+    return $pair->cdr();
 }
 
 sub pair_set_car {
     my ($pair, $car) = @_;
 
-    $pair->{car} = $car;
+    $pair->xar($car);
     return;
 }
 
 sub pair_set_cdr {
     my ($pair, $cdr) = @_;
 
-    $pair->{cdr} = $cdr;
+    $pair->xdr($cdr);
     return;
 }
 


### PR DESCRIPTION
Following the generally good notion that outside access to attributes should happen through methods.

This PR was extracted from the work in #245, but separated out because it turned out to be independent.