### PR TITLE
Use Bel's output injection to run example

### DIFF
--- a/t/examples/rll/test.t
+++ b/t/examples/rll/test.t
@@ -1,12 +1,17 @@
-#!perl
+#!perl -T
 use 5.006;
 
 use strict;
 use warnings;
+
 use Test::More;
+use Language::Bel::Test;
 
 plan tests => 1;
 
-my $output = `perl -Ilib bin/bel t/examples/rll/reverse-linked-list.bel`;
+my $output = output_of_eval_file("t/examples/rll/reverse-linked-list.bel");
 
-is $output, "<linked-list (5 4 3 2 1)>\n", "reverse-linked-list example works";
+is $output,
+    "<linked-list (5 4 3 2 1)>\n",
+    "reverse-linked-list example works";
+


### PR DESCRIPTION
Instead of starting a nested `perl` process.

Closes #213. While it doesn't end up using Bel streams (still some ways away), it gets rid of the nested process. This way is probably faster anyway.