### PR TITLE
Implement a preprocessor for the fastfuncs (take II)

### DIFF
--- a/lib/Language/Bel/Globals/FastFuncs.pm
+++ b/lib/Language/Bel/Globals/FastFuncs.pm
@@ -42,8 +42,7 @@ sub fastfunc__all {
     my ($bel, $f, $xs) = @_;
 
     while (!is_nil($xs)) {
-        my $p = $bel->call($f, $bel->car($xs));
-        if (is_nil($p)) {
+        if (is_nil($bel->call($f, $bel->car($xs)))) {
             return SYMBOL_NIL;
         }
         $xs = $bel->cdr($xs);
@@ -56,8 +55,7 @@ sub fastfunc__some {
     my ($bel, $f, $xs) = @_;
 
     while (!is_nil($xs)) {
-        my $p = $bel->call($f, $bel->car($xs));
-        if (!is_nil($p)) {
+        if (!is_nil($bel->call($f, $bel->car($xs)))) {
             return $xs;
         }
         $xs = $bel->cdr($xs);
@@ -2819,112 +2817,112 @@ sub fastfunc__c_plus {
 
 sub fastfunc__c_star {
     my ($bel, $x, $y) = @_;
-    
+
     my $xr = $bel->car($x);
     my $xi = $bel->car($bel->cdr($x));
-    
+
     my $yr = $bel->car($y);
     my $yi = $bel->car($bel->cdr($y));
-    
+
     my $real_part;
     {
         my $term1s;
         my $term1n_n;
         my $term1d_n;
-        
+
         {
             my $xs = $bel->car($xr);
             my $xn = $bel->car($bel->cdr($xr));
             my $xd = $bel->car($bel->cdr($bel->cdr($xr)));
-        
+
             my $ys = $bel->car($yr);
             my $yn = $bel->car($bel->cdr($yr));
             my $yd = $bel->car($bel->cdr($bel->cdr($yr)));
-        
+
             $term1s = is_symbol_of_name($xs, "-")
                 ? make_symbol(is_symbol_of_name($ys, "-") ? "+" : "-")
                 : $ys;
-        
+
             my $xn_n = 0;
             while (!is_nil($xn)) {
                 ++$xn_n;
                 $xn = $bel->cdr($xn);
             }
-        
+
             my $xd_n = 0;
             while (!is_nil($xd)) {
                 ++$xd_n;
                 $xd = $bel->cdr($xd);
             }
-        
+
             my $yn_n = 0;
             while (!is_nil($yn)) {
                 ++$yn_n;
                 $yn = $bel->cdr($yn);
             }
-        
+
             my $yd_n = 0;
             while (!is_nil($yd)) {
                 ++$yd_n;
                 $yd = $bel->cdr($yd);
             }
-        
+
             $term1n_n = $xn_n * $yn_n;
             $term1d_n = $xd_n * $yd_n;
         }
-    
+
         my $term2s;
         my $term2n_n;
         my $term2d_n;
-        
+
         {
             my $xs = $bel->car($xi);
             my $xn = $bel->car($bel->cdr($xi));
             my $xd = $bel->car($bel->cdr($bel->cdr($xi)));
-        
+
             my $ys = $bel->car($yi);
             my $yn = $bel->car($bel->cdr($yi));
             my $yd = $bel->car($bel->cdr($bel->cdr($yi)));
-        
+
             $term2s = is_symbol_of_name($xs, "-")
                 ? make_symbol(is_symbol_of_name($ys, "-") ? "+" : "-")
                 : $ys;
-        
+
             my $xn_n = 0;
             while (!is_nil($xn)) {
                 ++$xn_n;
                 $xn = $bel->cdr($xn);
             }
-        
+
             my $xd_n = 0;
             while (!is_nil($xd)) {
                 ++$xd_n;
                 $xd = $bel->cdr($xd);
             }
-        
+
             my $yn_n = 0;
             while (!is_nil($yn)) {
                 ++$yn_n;
                 $yn = $bel->cdr($yn);
             }
-        
+
             my $yd_n = 0;
             while (!is_nil($yd)) {
                 ++$yd_n;
                 $yd = $bel->cdr($yd);
             }
-        
+
             $term2n_n = $xn_n * $yn_n;
             $term2d_n = $xd_n * $yd_n;
         }
-    
+
         if (is_symbol_of_name($term1s, "-")) {
             if (is_symbol_of_name($term2s, "-")) {
                 my $n_n = $term2n_n * $term1d_n - $term1n_n * $term2d_n;
                 my $sign = $n_n < 1 ? "-" : "+";
                 $n_n = abs($n_n);
                 my $d_n = $term2d_n * $term1d_n;
-    
+
                 my $n = SYMBOL_NIL;
                 for (1..$n_n) {
                     $n = make_pair(
@@ -2932,7 +2930,7 @@ sub fastfunc__c_star {
                         $n,
                     );
                 }
-    
+
                 my $d = SYMBOL_NIL;
                 for (1..$d_n) {
                     $d = make_pair(
@@ -2940,7 +2938,7 @@ sub fastfunc__c_star {
                         $d,
                     );
                 }
-    
+
                 $real_part = make_pair(
                     make_symbol($sign),
                     make_pair(
@@ -2955,7 +2953,7 @@ sub fastfunc__c_star {
             else {
                 my $n_n = $term1n_n * $term2d_n + $term2n_n * $term1d_n;
                 my $d_n = $term1d_n * $term2d_n;
-    
+
                 my $n = SYMBOL_NIL;
                 for (1..$n_n) {
                     $n = make_pair(
@@ -2963,7 +2961,7 @@ sub fastfunc__c_star {
                         $n,
                     );
                 }
-    
+
                 my $d = SYMBOL_NIL;
                 for (1..$d_n) {
                     $d = make_pair(
@@ -2971,7 +2969,7 @@ sub fastfunc__c_star {
                         $d,
                     );
                 }
-    
+
                 $real_part = make_pair(
                     make_symbol("-"),
                     make_pair(
@@ -2988,7 +2986,7 @@ sub fastfunc__c_star {
             if (is_symbol_of_name($term2s, "-")) {
                 my $n_n = $term1n_n * $term2d_n + $term2n_n * $term1d_n;
                 my $d_n = $term1d_n * $term2d_n;
-    
+
                 my $n = SYMBOL_NIL;
                 for (1..$n_n) {
                     $n = make_pair(
@@ -2996,7 +2994,7 @@ sub fastfunc__c_star {
                         $n,
                     );
                 }
-    
+
                 my $d = SYMBOL_NIL;
                 for (1..$d_n) {
                     $d = make_pair(
@@ -3004,7 +3002,7 @@ sub fastfunc__c_star {
                         $d,
                     );
                 }
-    
+
                 $real_part = make_pair(
                     make_symbol("+"),
                     make_pair(
@@ -3021,7 +3019,7 @@ sub fastfunc__c_star {
                 my $sign = $n_n < 1 && $term2n_n > 0 ? "-" : "+";
                 $n_n = abs($n_n);
                 my $d_n = $term1d_n * $term2d_n;
-    
+
                 my $n = SYMBOL_NIL;
                 for (1..$n_n) {
                     $n = make_pair(
@@ -3029,7 +3027,7 @@ sub fastfunc__c_star {
                         $n,
                     );
                 }
-    
+
                 my $d = SYMBOL_NIL;
                 for (1..$d_n) {
                     $d = make_pair(
@@ -3037,7 +3035,7 @@ sub fastfunc__c_star {
                         $d,
                     );
                 }
-    
+
                 $real_part = make_pair(
                     make_symbol($sign),
                     make_pair(
@@ -3051,104 +3049,104 @@ sub fastfunc__c_star {
             }
         }
     }
-    
+
     my $imaginary_part;
     {
         my $term1s;
         my $term1n_n;
         my $term1d_n;
-        
+
         {
             my $xs = $bel->car($xi);
             my $xn = $bel->car($bel->cdr($xi));
             my $xd = $bel->car($bel->cdr($bel->cdr($xi)));
-        
+
             my $ys = $bel->car($yr);
             my $yn = $bel->car($bel->cdr($yr));
             my $yd = $bel->car($bel->cdr($bel->cdr($yr)));
-        
+
             $term1s = is_symbol_of_name($xs, "-")
                 ? make_symbol(is_symbol_of_name($ys, "-") ? "+" : "-")
                 : $ys;
-        
+
             my $xn_n = 0;
             while (!is_nil($xn)) {
                 ++$xn_n;
                 $xn = $bel->cdr($xn);
             }
-        
+
             my $xd_n = 0;
             while (!is_nil($xd)) {
                 ++$xd_n;
                 $xd = $bel->cdr($xd);
             }
-        
+
             my $yn_n = 0;
             while (!is_nil($yn)) {
                 ++$yn_n;
                 $yn = $bel->cdr($yn);
             }
-        
+
             my $yd_n = 0;
             while (!is_nil($yd)) {
                 ++$yd_n;
                 $yd = $bel->cdr($yd);
             }
-        
+
             $term1n_n = $xn_n * $yn_n;
             $term1d_n = $xd_n * $yd_n;
         }
-    
+
         my $term2s;
         my $term2n_n;
         my $term2d_n;
-        
+
         {
             my $xs = $bel->car($xr);
             my $xn = $bel->car($bel->cdr($xr));
             my $xd = $bel->car($bel->cdr($bel->cdr($xr)));
-        
+
             my $ys = $bel->car($yi);
             my $yn = $bel->car($bel->cdr($yi));
             my $yd = $bel->car($bel->cdr($bel->cdr($yi)));
-        
+
             $term2s = is_symbol_of_name($xs, "-")
                 ? make_symbol(is_symbol_of_name($ys, "-") ? "+" : "-")
                 : $ys;
-        
+
             my $xn_n = 0;
             while (!is_nil($xn)) {
                 ++$xn_n;
                 $xn = $bel->cdr($xn);
             }
-        
+
             my $xd_n = 0;
             while (!is_nil($xd)) {
                 ++$xd_n;
                 $xd = $bel->cdr($xd);
             }
-        
+
             my $yn_n = 0;
             while (!is_nil($yn)) {
                 ++$yn_n;
                 $yn = $bel->cdr($yn);
             }
-        
+
             my $yd_n = 0;
             while (!is_nil($yd)) {
                 ++$yd_n;
                 $yd = $bel->cdr($yd);
             }
-        
+
             $term2n_n = $xn_n * $yn_n;
             $term2d_n = $xd_n * $yd_n;
         }
-    
+
         if (is_symbol_of_name($term1s, "-")) {
             if (is_symbol_of_name($term2s, "-")) {
                 my $n_n = $term1n_n * $term2d_n + $term2n_n * $term1d_n;
                 my $d_n = $term1d_n * $term2d_n;
-    
+
                 my $n = SYMBOL_NIL;
                 for (1..$n_n) {
                     $n = make_pair(
@@ -3156,7 +3154,7 @@ sub fastfunc__c_star {
                         $n,
                     );
                 }
-    
+
                 my $d = SYMBOL_NIL;
                 for (1..$d_n) {
                     $d = make_pair(
@@ -3164,7 +3162,7 @@ sub fastfunc__c_star {
                         $d,
                     );
                 }
-    
+
                 $imaginary_part = make_pair(
                     make_symbol("-"),
                     make_pair(
@@ -3181,7 +3179,7 @@ sub fastfunc__c_star {
                 my $sign = $n_n < 1 ? "-" : "+";
                 $n_n = abs($n_n);
                 my $d_n = $term2d_n * $term1d_n;
-    
+
                 my $n = SYMBOL_NIL;
                 for (1..$n_n) {
                     $n = make_pair(
@@ -3189,7 +3187,7 @@ sub fastfunc__c_star {
                         $n,
                     );
                 }
-    
+
                 my $d = SYMBOL_NIL;
                 for (1..$d_n) {
                     $d = make_pair(
@@ -3197,7 +3195,7 @@ sub fastfunc__c_star {
                         $d,
                     );
                 }
-    
+
                 $imaginary_part = make_pair(
                     make_symbol($sign),
                     make_pair(
@@ -3216,7 +3214,7 @@ sub fastfunc__c_star {
                 my $sign = $n_n < 1 ? "-" : "+";
                 $n_n = abs($n_n);
                 my $d_n = $term1d_n * $term2d_n;
-    
+
                 my $n = SYMBOL_NIL;
                 for (1..$n_n) {
                     $n = make_pair(
@@ -3224,7 +3222,7 @@ sub fastfunc__c_star {
                         $n,
                     );
                 }
-    
+
                 my $d = SYMBOL_NIL;
                 for (1..$d_n) {
                     $d = make_pair(
@@ -3232,7 +3230,7 @@ sub fastfunc__c_star {
                         $d,
                     );
                 }
-    
+
                 $imaginary_part = make_pair(
                     make_symbol($sign),
                     make_pair(
@@ -3247,7 +3245,7 @@ sub fastfunc__c_star {
             else {
                 my $n_n = $term1n_n * $term2d_n + $term2n_n * $term1d_n;
                 my $d_n = $term1d_n * $term2d_n;
-    
+
                 my $n = SYMBOL_NIL;
                 for (1..$n_n) {
                     $n = make_pair(
@@ -3255,7 +3253,7 @@ sub fastfunc__c_star {
                         $n,
                     );
                 }
-    
+
                 my $d = SYMBOL_NIL;
                 for (1..$d_n) {
                     $d = make_pair(
@@ -3263,7 +3261,7 @@ sub fastfunc__c_star {
                         $d,
                     );
                 }
-    
+
                 $imaginary_part = make_pair(
                     make_symbol("+"),
                     make_pair(
@@ -3277,7 +3275,7 @@ sub fastfunc__c_star {
             }
         }
     }
-    
+
     return make_pair(
         $real_part,
         make_pair(

--- a/lib/Language/Bel/Globals/FastFuncs/Deparser.pm
+++ b/lib/Language/Bel/Globals/FastFuncs/Deparser.pm
@@ -83,6 +83,12 @@ sub deparse {
         my $args = deparse($children[1]);
         return "$fn$args";
     }
+    elsif ($type eq "method_call") {
+        my $invocant = deparse($children[0]);
+        my $method = deparse($children[1]);
+        my $args = deparse($children[2]);
+        return "$invocant\->$method$args";
+    }
     elsif ($type eq "argument_list") {
         my $arguments = join(", ", map { deparse($_) } @children);
         return "($arguments)";

--- a/lib/Language/Bel/Globals/FastFuncs/Deparser.pm
+++ b/lib/Language/Bel/Globals/FastFuncs/Deparser.pm
@@ -1,0 +1,107 @@
+package Language::Bel::Globals::FastFuncs::Deparser;
+
+use 5.006;
+use strict;
+use warnings;
+
+use Exporter 'import';
+
+sub deparse {
+    my ($ast) = @_;
+
+    my $type = $ast->{type};
+    my @children = exists $ast->{children}
+        ? @{ $ast->{children} }
+        : ();
+
+    if ($type eq "statement_list") {
+        my $i = 0;
+
+        return join("", map {
+            my $indent = " " x 4;
+            my $newline = "\n";
+            my $statement = deparse($_);
+
+            my $indented = join("\n", map {
+                "$indent$_"
+            } split(/\n/, $statement));
+
+            $i++ == 0 && $_->{type} eq "my_statement"
+                ? "$indented$newline$newline"
+                : $i == @children && $i > 2 && $_->{type} eq "return_statement"
+                    ? "$newline$indented$newline"
+                    : "$indented$newline";
+        } @children);
+    }
+    elsif ($type eq "return_statement") {
+        return "return " . deparse($children[0]) . ";";
+    }
+    elsif ($type eq "my_statement") {
+        return deparse($children[0]) . ";";
+    }
+    elsif ($type eq "expr_statement") {
+        return deparse($children[0]) . ";";
+    }
+    elsif ($type eq "while_statement") {
+        my $condition = deparse($children[0]);
+        my $statement_list = deparse($children[1]);
+        return "while ($condition) {\n$statement_list}";
+    }
+    elsif ($type eq "if_statement") {
+        my $condition = deparse($children[0]);
+        my $statement_list = deparse($children[1]);
+        return "if ($condition) {\n$statement_list}";
+    }
+    elsif ($type eq "my") {
+        my $vars = deparse($children[0]);
+        my $maybe_assignment = @children > 1
+            ? " = " . deparse($children[1])
+            : "";
+        return "my $vars$maybe_assignment";
+    }
+    elsif ($type eq "variable_list") {
+        my $variables = join(", ", map { deparse($_) } @children);
+        return "($variables)";
+    }
+    elsif ($type eq "variable") {
+        return $ast->{name};
+    }
+    elsif ($type eq "bareword") {
+        return $ast->{name};
+    }
+    elsif ($type eq "qmark") {
+        return deparse($children[0]) . " ? " . deparse($children[1]);
+    }
+    elsif ($type eq "colon") {
+        return deparse($children[0]) . " : " . deparse($children[1]);
+    }
+    elsif ($type eq "assign") {
+        return deparse($children[0]) . " = " . deparse($children[1]);
+    }
+    elsif ($type eq "call") {
+        my $fn = deparse($children[0]);
+        my $args = deparse($children[1]);
+        return "$fn$args";
+    }
+    elsif ($type eq "argument_list") {
+        my $arguments = join(", ", map { deparse($_) } @children);
+        return "($arguments)";
+    }
+    elsif ($type eq "sub") {
+        my $statement_list = deparse($children[0]);
+        return "sub {\n$statement_list}";
+    }
+    elsif ($type eq "not") {
+        my $expr = deparse($children[0]);
+        return "!$expr";
+    }
+    else {
+        die "Unknown AST type '$type'";
+    }
+}
+
+our @EXPORT_OK = qw(
+    deparse
+);
+
+1;

--- a/lib/Language/Bel/Globals/FastFuncs/Lexer.pm
+++ b/lib/Language/Bel/Globals/FastFuncs/Lexer.pm
@@ -6,7 +6,11 @@ use warnings;
 
 use Exporter 'import';
 
-my %PUNCTUATION = (
+my %PUNCTUATION_2 = (
+    "->" => "arrow",
+);
+
+my %PUNCTUATION_1 = (
     "(" => "opening_paren",
     ")" => "closing_paren",
     "," => "comma",
@@ -54,7 +58,11 @@ sub tokenize {
             $PUSH_TOKEN->("variable", name => $1);
             $pos += length($1);
         }
-        elsif (my $type = $PUNCTUATION{substr($s, 0, 1)}) {
+        elsif (my $type = $PUNCTUATION_2{substr($s, 0, 2)}) {
+            $PUSH_TOKEN->($type);
+            $pos += 2;
+        }
+        elsif ($type = $PUNCTUATION_1{substr($s, 0, 1)}) {
             $PUSH_TOKEN->($type);
             $pos += 1;
         }

--- a/lib/Language/Bel/Globals/FastFuncs/Lexer.pm
+++ b/lib/Language/Bel/Globals/FastFuncs/Lexer.pm
@@ -1,0 +1,74 @@
+package Language::Bel::Globals::FastFuncs::Lexer;
+
+use 5.006;
+use strict;
+use warnings;
+
+use Exporter 'import';
+
+my %PUNCTUATION = (
+    "(" => "opening_paren",
+    ")" => "closing_paren",
+    "," => "comma",
+    ":" => "colon",
+    ";" => "semicolon",
+    "=" => "assign",
+    "?" => "qmark",
+    "{" => "opening_brace",
+    "}" => "closing_brace",
+);
+
+sub tokenize {
+    my ($input) = @_;
+
+    my @tokens;
+    my $pos = 0;
+
+    my $PUSH_TOKEN = sub {
+        my ($type, @properties) = @_;
+
+        push @tokens, {
+            type => $type,
+            pos => $pos,
+            @properties,
+        };
+    };
+
+    while ($pos < length($input)) {
+        substr($input, $pos) =~ /^(\s+)/
+            and $pos += length($1);
+
+        last if $pos >= length($input);
+
+        my $s = substr($input, $pos);
+
+        if ($s =~ /^(return|sub|my)\b/) {
+            $PUSH_TOKEN->($1);
+            $pos += length($1);
+        }
+        elsif ($s =~ /^(\w+)\b/) {
+            $PUSH_TOKEN->("bareword", name => $1);
+            $pos += length($1);
+        }
+        elsif ($s =~ /^([\$\@]\w+)\b/) {
+            $PUSH_TOKEN->("variable", name => $1);
+            $pos += length($1);
+        }
+        elsif (my $type = $PUNCTUATION{substr($s, 0, 1)}) {
+            $PUSH_TOKEN->($type);
+            $pos += 1;
+        }
+        else {
+            my $fragment = substr($input, $pos, 10);
+            die "Do not know how to handle '$fragment...'\n";
+        }
+    }
+
+    return @tokens;
+}
+
+our @EXPORT_OK = qw(
+    tokenize
+);
+
+1;

--- a/lib/Language/Bel/Globals/FastFuncs/Macros.pm
+++ b/lib/Language/Bel/Globals/FastFuncs/Macros.pm
@@ -1,0 +1,52 @@
+package Language::Bel::Globals::FastFuncs::Macros;
+
+use 5.006;
+use strict;
+use warnings;
+
+use Exporter 'import';
+
+sub CALL {
+    my ($fn, @args) = @_;
+}
+
+sub GENERATE_WHERE {
+    my () = @_;
+}
+
+sub IF {
+    my ($condition, $body) = @_;
+}
+
+sub ITERATE_FORWARD {
+    my ($variable, $list, $body) = @_;
+}
+
+sub ITERATE_FORWARD_OF {
+    my ($variable, $pair, $list, $body) = @_;
+}
+
+sub NIL {
+    my () = @_;
+}
+
+sub T {
+    my () = @_;
+}
+
+sub UNLESS {
+    my ($condition, $body) = @_;
+}
+
+our @EXPORT = qw(
+    CALL
+    GENERATE_WHERE
+    IF
+    ITERATE_FORWARD
+    ITERATE_FORWARD_OF
+    NIL
+    T
+    UNLESS
+);
+
+1;

--- a/lib/Language/Bel/Globals/FastFuncs/Parser.pm
+++ b/lib/Language/Bel/Globals/FastFuncs/Parser.pm
@@ -1,0 +1,350 @@
+package Language::Bel::Globals::FastFuncs::Parser;
+
+use 5.006;
+use strict;
+use warnings;
+
+use Language::Bel::Globals::FastFuncs::Lexer qw(
+    tokenize
+);
+
+use Exporter 'import';
+
+sub parse {
+    my ($input) = @_;
+
+    my @tokens = tokenize($input);
+
+    my $parser = bless(
+        { tokens => [@tokens] },
+        __PACKAGE__,
+    );
+
+    return $parser->parse_statement_list();
+}
+
+sub token_count {
+    my ($self) = @_;
+
+    return scalar(@{ $self->{tokens} });
+}
+
+sub there_are_tokens_left {
+    my ($self) = @_;
+
+    return $self->token_count() > 0;
+}
+
+sub peek_token {
+    my ($self) = @_;
+
+    die "Tried to peek into empty token stream"
+        unless $self->there_are_tokens_left();
+
+    return $self->{tokens}->[0];
+}
+
+sub peek_token_of_type {
+    my ($self, $type) = @_;
+
+    my $token = $self->peek_token();
+
+    return $token->{type} eq $type;
+}
+
+sub consume_token {
+    my ($self) = @_;
+
+    die "Tried to consume empty token stream"
+        unless $self->there_are_tokens_left();
+
+    return shift(@{ $self->{tokens} });
+}
+
+sub expect_token_of_type {
+    my ($self, $type) = @_;
+
+    die "Expected token type '$type', found end of token stream"
+        unless $self->there_are_tokens_left();
+
+    my $token = $self->peek_token();
+    my $actual_type = $token->{type};
+
+    die "Expected token type '$type', found type '$actual_type'"
+        unless $type eq $actual_type;
+
+    return;
+}
+
+sub consume_token_of_type {
+    my ($self, $type) = @_;
+
+    $self->expect_token_of_type($type);
+    return $self->consume_token();
+}
+
+sub parse_statement_list {
+    my ($self) = @_;
+
+    my @children;
+    my $ast = {
+        type => "statement_list",
+        children => \@children,
+    };
+
+    while ($self->there_are_tokens_left()
+        && !$self->peek_token_of_type("closing_brace")) {
+        push @children, $self->parse_statement();
+    }
+
+    return $ast;
+}
+
+sub pretty {
+    my ($token) = @_;
+
+    my $kvs = join(", ", map {
+        $_ . " => " . $token->{$_}
+    } keys(%{ $token }));
+    return "{ $kvs }";
+}
+
+sub parse_statement {
+    my ($self) = @_;
+
+    # is only called after we confirmed that there are tokens left,
+    # so we're entitled to call peek_token()
+
+    my $type;
+    my $child;
+
+    my $token = $self->peek_token();
+    if ($token->{type} eq "return") {
+        $type = "return_statement";
+        $self->consume_token();
+        $child = $self->parse_expression();
+    }
+    elsif ($token->{type} eq "my") {
+        $type = "my_statement";
+        $child = $self->parse_my();
+    }
+    elsif ($token->{type} eq "bareword") {
+        $type = "expr_statement";
+        $child = $self->parse_expression();
+    }
+    else {
+        die "Unrecognized token in statement: ", pretty($token);
+    }
+
+    $self->consume_token_of_type("semicolon");
+
+    return {
+        type => $type,
+        children => [$child],
+    };
+}
+
+sub is_stopper {
+    my ($token) = @_;
+
+    return $token->{type} =~ /^(?:semicolon|closing_paren|comma)$/;
+}
+
+sub parse_expression {
+    my ($self) = @_;
+
+    die "Expected expression"
+        unless $self->there_are_tokens_left();
+
+    my @term_stack;
+    my @op_stack;
+
+    my $SHIFT = sub {
+        my ($term) = @_;
+
+        push @term_stack, $term;
+    };
+
+    my $REDUCE = sub {
+        die "Not enough terms on the term stack"
+            unless @term_stack >= 2;
+        die "No operator on the op stack"
+            unless @op_stack;
+
+        # note the reverse order; last in, first out
+        my $term2 = pop @term_stack;
+        my $term1 = pop @term_stack;
+
+        my $op = pop @op_stack;
+
+        push @term_stack, {
+            type => $op->{type},
+            children => [$term1, $term2],
+        };
+    };
+
+    my $expect_mode = "term";
+    my $token;
+    while (!is_stopper($token = $self->peek_token())) {
+        my $token_count_at_beginning = $self->token_count();
+
+        if ($expect_mode eq "term") {
+            if ($token->{type} =~ /^(?:bareword|variable)$/) {
+                $SHIFT->($self->consume_token());
+                $expect_mode = "op";
+            }
+            elsif ($token->{type} eq "my") {
+                $SHIFT->($self->parse_my());
+                $expect_mode = "op";
+            }
+            elsif ($token->{type} eq "sub") {
+                $SHIFT->($self->parse_sub());
+                $expect_mode = "op";
+            }
+            else {
+                die "Unrecognized token in term position: ", pretty($token);
+            }
+        }
+        else { # expecting an op(erator)
+            if ($token->{type} eq "opening_paren") {
+                $self->consume_token();
+                my $argument_list = $self->parse_argument_list();
+                $self->consume_token_of_type("closing_paren");
+
+                my $term = pop @term_stack;
+                $SHIFT->({
+                    type => "call",
+                    children => [$term, $argument_list],
+                });
+
+                # function call parens are a postcircumfix; so we're still
+                # expecting an op after it
+                $expect_mode = "op";
+            }
+            elsif ($token->{type} =~ /^(?:colon|qmark)$/) {
+                push @op_stack, $self->consume_token();
+
+                $expect_mode = "term";
+            }
+            else {
+                die "Unrecognized token in operator position: ",
+                    pretty($token);
+            }
+        }
+
+        die "Didn't consume any tokens; stuck at ", pretty($token)
+            unless $self->token_count() < $token_count_at_beginning;
+    }
+
+    die "Expected term after ", $op_stack[-1]->{type},
+        "; found ", $token->{type}
+        if $expect_mode eq "term";
+
+    die "There are no terms left on stack"
+        unless @term_stack;
+
+    while (@op_stack) {
+        $REDUCE->();
+    }
+
+    return $term_stack[-1];
+}
+
+sub parse_argument_list {
+    my ($self) = @_;
+
+    my @children;
+
+    unless ($self->peek_token_of_type("closing_paren")) {
+        push @children, $self->parse_expression();
+
+        while ($self->peek_token_of_type("comma")) {
+            $self->consume_token();
+            push @children, $self->parse_expression();
+        }
+
+        $self->expect_token_of_type("closing_paren");
+    }
+
+    return {
+        type => "argument_list",
+        children => \@children,
+    };
+}
+
+sub parse_my {
+    my ($self) = @_;
+
+    $self->consume_token_of_type("my");
+
+    my @children;
+    if ($self->peek_token_of_type("variable")) {
+        push @children, $self->consume_token();
+    }
+    elsif ($self->peek_token_of_type("opening_paren")) {
+        $self->consume_token();
+
+        push @children, $self->parse_variable_list();
+
+        $self->consume_token_of_type("closing_paren");
+    }
+    else {
+        die "Expected variable or opening_paren, found ",
+            pretty($self->peek_token());
+    }
+
+    if ($self->peek_token_of_type("assign")) {
+        $self->consume_token();
+        push @children, $self->parse_expression();
+    }
+
+    return {
+        type => "my",
+        children => \@children,
+    };
+}
+
+sub parse_variable_list {
+    my ($self) = @_;
+
+    my @children;
+
+    unless ($self->peek_token_of_type("closing_paren")) {
+        push @children, $self->consume_token_of_type("variable");
+
+        while ($self->peek_token_of_type("comma")) {
+            $self->consume_token();
+            push @children, $self->consume_token_of_type("variable");
+        }
+
+        $self->expect_token_of_type("closing_paren");
+    }
+
+    return {
+        type => "variable_list",
+        children => \@children,
+    };
+}
+
+sub parse_sub {
+    my ($self) = @_;
+
+    $self->consume_token_of_type("sub");
+    $self->consume_token_of_type("opening_brace");
+
+    my @children;
+    push @children, $self->parse_statement_list();
+
+    $self->consume_token_of_type("closing_brace");
+
+    return {
+        type => "sub",
+        children => \@children,
+    };
+}
+
+our @EXPORT_OK = qw(
+    parse
+);
+
+1;

--- a/lib/Language/Bel/Globals/FastFuncs/Preprocessor.pm
+++ b/lib/Language/Bel/Globals/FastFuncs/Preprocessor.pm
@@ -4,18 +4,73 @@ use 5.006;
 use strict;
 use warnings;
 
+use Language::Bel::Globals::FastFuncs::Parser qw(
+    parse
+);
+use Language::Bel::Globals::FastFuncs::Visitor qw(
+    visit
+);
+use Language::Bel::Globals::FastFuncs::Deparser qw(
+    deparse
+);
+
 use Exporter 'import';
+
+sub expand {
+    my ($input) = @_;
+
+    return deparse(visit(parse($input)));
+}
 
 sub preprocess {
     open my $SOURCE, "<", "lib/Language/Bel/Globals/FastFuncs/Source.pm"
         or die "Couldn't open source file: $!";
 
+    my @function_body_lines;
+    my $reading_function_body = 0;
+    my $seen_cutoff = 0;
+
     my @result;
     while (my $line = <$SOURCE>) {
+        next
+            if $line =~ /^use Language::Bel::Globals::FastFuncs::Macros;$/;
+
         $line =~ s{Language::Bel::Globals::FastFuncs::Source}
                   {Language::Bel::Globals::FastFuncs};
 
-        push @result, $line;
+        $line =~ s/^ +$//;
+
+        if ($line =~ /^sub (\w+)/) {
+            push @result, $line;
+
+            my $sub_name = $1;
+            # right now we have a cutoff, so we don't have to parse/handle
+            # all of the fastfuncs source before benefitting from some of
+            # them -- this cutoff will move gradually downwards and
+            # eventually disappear
+            if ($sub_name eq "fastfunc__where__some") {
+                $seen_cutoff = 1;
+            }
+
+            if (!$seen_cutoff) {
+                $reading_function_body = 1;
+                @function_body_lines = ();
+            }
+        }
+        elsif ($reading_function_body) {
+            if ($line =~ /^\}$/) {
+                push @result, expand(join("", @function_body_lines));
+                push @result, $line;
+
+                $reading_function_body = 0;
+            }
+            else {
+                push @function_body_lines, $line;
+            }
+        }
+        else {
+            push @result, $line;
+        }
     }
 
     close $SOURCE;
@@ -33,6 +88,7 @@ sub generate_target_file {
 }
 
 our @EXPORT_OK = qw(
+    expand
     generate_target_file
     preprocess
 );

--- a/lib/Language/Bel/Globals/FastFuncs/Preprocessor.pm
+++ b/lib/Language/Bel/Globals/FastFuncs/Preprocessor.pm
@@ -1,0 +1,40 @@
+package Language::Bel::Globals::FastFuncs::Preprocessor;
+
+use 5.006;
+use strict;
+use warnings;
+
+use Exporter 'import';
+
+sub preprocess {
+    open my $SOURCE, "<", "lib/Language/Bel/Globals/FastFuncs/Source.pm"
+        or die "Couldn't open source file: $!";
+
+    my @result;
+    while (my $line = <$SOURCE>) {
+        $line =~ s{Language::Bel::Globals::FastFuncs::Source}
+                  {Language::Bel::Globals::FastFuncs};
+
+        push @result, $line;
+    }
+
+    close $SOURCE;
+
+    return join("", @result);
+}
+
+sub generate_target_file {
+    open my $TARGET, ">", "lib/Language/Bel/Globals/FastFuncs.pm"
+        or die "Couldn't open target file: $!";
+
+    print {$TARGET} preprocess();
+
+    close $TARGET;
+}
+
+our @EXPORT_OK = qw(
+    generate_target_file
+    preprocess
+);
+
+1;

--- a/lib/Language/Bel/Globals/FastFuncs/Source.pm
+++ b/lib/Language/Bel/Globals/FastFuncs/Source.pm
@@ -1,0 +1,3772 @@
+package Language::Bel::Globals::FastFuncs::Source;
+
+use 5.006;
+use strict;
+use warnings;
+
+use Language::Bel::Types qw(
+    atoms_are_identical
+    is_char
+    is_nil
+    is_pair
+    is_symbol
+    is_symbol_of_name
+    make_char
+    make_pair
+    make_symbol
+);
+use Language::Bel::Primitives;
+use Language::Bel::Symbols::Common qw(
+    SYMBOL_A
+    SYMBOL_D
+    SYMBOL_NIL
+    SYMBOL_T
+);
+use Language::Bel::Printer;
+
+use Exporter 'import';
+
+sub fastfunc__no {
+    my ($bel, $x) = @_;
+
+    return is_nil($x) ? SYMBOL_T : SYMBOL_NIL;
+}
+
+sub fastfunc__atom {
+    my ($bel, $x) = @_;
+
+    return is_pair($x) ? SYMBOL_NIL : SYMBOL_T;
+}
+
+sub fastfunc__all {
+    my ($bel, $f, $xs) = @_;
+
+    while (!is_nil($xs)) {
+        my $p = $bel->{call}->($f, $bel->car($xs));
+        if (is_nil($p)) {
+            return SYMBOL_NIL;
+        }
+        $xs = $bel->cdr($xs);
+    }
+
+    return SYMBOL_T;
+}
+
+sub fastfunc__some {
+    my ($bel, $f, $xs) = @_;
+
+    while (!is_nil($xs)) {
+        my $p = $bel->{call}->($f, $bel->car($xs));
+        if (!is_nil($p)) {
+            return $xs;
+        }
+        $xs = $bel->cdr($xs);
+    }
+
+    return SYMBOL_NIL;
+}
+
+sub fastfunc__where__some {
+    my ($bel, $f, $xs) = @_;
+
+    while (!is_nil($xs)) {
+        my $p = $bel->{call}->($f, $bel->car($xs));
+        if (!is_nil($p)) {
+            return make_pair(
+                make_pair(
+                    make_symbol("xs"),
+                    $xs,
+                ),
+                make_pair(
+                    SYMBOL_D,
+                    SYMBOL_NIL,
+                ),
+            );
+        }
+        $xs = $bel->cdr($xs);
+    }
+
+    return SYMBOL_NIL;
+}
+
+sub fastfunc__reduce {
+    my ($bel, $f, $xs) = @_;
+
+    my @values;
+    while (!is_nil($xs)) {
+        push @values, $bel->car($xs);
+        $xs = $bel->cdr($xs);
+    }
+
+    my $result = @values ? pop(@values) : SYMBOL_NIL;
+    while (@values) {
+        my $value = pop(@values);
+        $result = $bel->{call}->($f, $value, $result);
+    }
+
+    return $result;
+}
+
+sub fastfunc__cons {
+    my ($bel, @args) = @_;
+
+    my $result = @args ? pop(@args) : SYMBOL_NIL;
+    while (@args) {
+        my $value = pop(@args);
+        $result = make_pair($value, $result);
+    }
+
+    return $result;
+}
+
+sub fastfunc__append {
+    my ($bel, @args) = @_;
+
+    my $result = @args ? pop(@args) : SYMBOL_NIL;
+    while (@args) {
+        my $list = pop(@args);
+        my @values;
+        while (!is_nil($list)) {
+            push @values, $bel->car($list);
+            $list = $bel->cdr($list);
+        }
+        while (@values) {
+            my $value = pop(@values);
+            $result = make_pair($value, $result);
+        }
+    }
+
+    return $result;
+}
+
+sub fastfunc__snoc {
+    my ($bel, @args) = @_;
+
+    my $result = SYMBOL_NIL;
+    while (scalar(@args) > 1) {
+        my $value = pop(@args);
+        $result = make_pair($value, $result);
+    }
+    if (@args) {
+        my $list = pop(@args);
+        my @values;
+        while (!is_nil($list)) {
+            push @values, $bel->car($list);
+            $list = $bel->cdr($list);
+        }
+        while (@values) {
+            my $value = pop(@values);
+            $result = make_pair($value, $result);
+        }
+    }
+
+    return $result;
+}
+
+sub fastfunc__list {
+    my ($bel, @args) = @_;
+
+    my $result = SYMBOL_NIL;
+    while (@args) {
+        my $value = pop(@args);
+        $result = make_pair($value, $result);
+    }
+
+    return $result;
+}
+
+sub fastfunc__map {
+    my ($bel, $f, @ls) = @_;
+
+    return SYMBOL_NIL
+        unless @ls;
+
+    my @result;
+
+    ELEMENT:
+    while (1) {
+        my @arguments;
+        for my $list (@ls) {
+            last ELEMENT
+                if (is_nil($list));
+
+            push @arguments, $bel->car($list);
+            $list = $bel->cdr($list);
+        }
+        push @result, $bel->{call}->($f, @arguments);
+    }
+
+    my $result = SYMBOL_NIL;
+    for my $v (reverse(@result)) {
+        $result = make_pair($v, $result);
+    }
+
+    return $result;
+}
+
+sub fastfunc__eq  {
+    my ($bel, @args) = @_;
+
+    my @stack = [@args];
+    while (@stack) {
+        my @values = @{pop(@stack)};
+        next unless @values;
+        my $some_atom = "";
+        for my $value (@values) {
+            if (!is_pair($value)) {
+                $some_atom = 1;
+                last;
+            }
+        }
+        if ($some_atom) {
+            my $car_values = $values[0];
+            for my $value (@values) {
+                if (!atoms_are_identical($value, $car_values)) {
+                    return SYMBOL_NIL;
+                }
+            }
+        }
+        else {
+            push @stack, [map { $bel->cdr($_) } @values];
+            push @stack, [map { $bel->car($_) } @values];
+        }
+    }
+
+    return SYMBOL_T;
+}
+
+sub fastfunc__symbol {
+    my ($bel, $x) = @_;
+
+    return is_symbol($x) ? SYMBOL_T : SYMBOL_NIL;
+}
+
+sub fastfunc__pair {
+    my ($bel, $x) = @_;
+
+    return is_pair($x) ? SYMBOL_T : SYMBOL_NIL;
+}
+
+sub fastfunc__char {
+    my ($bel, $x) = @_;
+
+    return is_char($x) ? SYMBOL_T : SYMBOL_NIL;
+}
+
+sub fastfunc__proper {
+    my ($bel, $x) = @_;
+
+    while (!is_nil($x)) {
+        if (!is_pair($x)) {
+            return SYMBOL_NIL;
+        }
+        $x = $bel->cdr($x);
+    }
+
+    return SYMBOL_T;
+}
+
+sub fastfunc__string {
+    my ($bel, $x) = @_;
+
+    while (!is_nil($x)) {
+        if (!is_pair($x)) {
+            return SYMBOL_NIL;
+        }
+        if (!is_char($bel->car($x))) {
+            return SYMBOL_NIL;
+        }
+        $x = $bel->cdr($x);
+    }
+
+    return SYMBOL_T;
+}
+
+sub fastfunc__mem {
+    my ($bel, $x, $ys, $f) = @_;
+
+    if (defined($f)) {
+        while (!is_nil($ys)) {
+            my $p = $bel->{call}->($f, $bel->car($ys), $x);
+            if (!is_nil($p)) {
+                return $ys;
+            }
+            $ys = $bel->cdr($ys);
+        }
+    }
+    else {
+        ELEMENT:
+        while (!is_nil($ys)) {
+            my @stack = [$bel->car($ys), $x];
+            while (@stack) {
+                my @values = @{pop(@stack)};
+                next unless @values;
+                my $some_atom = "";
+                for my $value (@values) {
+                    if (!is_pair($value)) {
+                        $some_atom = 1;
+                        last;
+                    }
+                }
+                if ($some_atom) {
+                    my $car_values = $values[0];
+                    for my $value (@values) {
+                        if (!atoms_are_identical($value, $car_values)) {
+                            $ys = $bel->cdr($ys);
+                            next ELEMENT;
+                        }
+                    }
+                }
+                else {
+                    push @stack, [map { $bel->cdr($_) } @values];
+                    push @stack, [map { $bel->car($_) } @values];
+                }
+            }
+
+            return $ys;
+        }
+    }
+
+    return SYMBOL_NIL;
+}
+
+sub fastfunc__where__mem {
+    my ($bel, $x, $ys, $f) = @_;
+
+    if (defined($f)) {
+        while (!is_nil($ys)) {
+            my $p = $bel->{call}->($f, $bel->car($ys), $x);
+            if (!is_nil($p)) {
+                return make_pair(
+                    make_pair(
+                        make_symbol("xs"),
+                        $ys,
+                    ),
+                    make_pair(
+                        SYMBOL_D,
+                        SYMBOL_NIL,
+                    ),
+                );
+            }
+            $ys = $bel->cdr($ys);
+        }
+    }
+    else {
+        ELEMENT:
+        while (!is_nil($ys)) {
+            my @stack = [$bel->car($ys), $x];
+            while (@stack) {
+                my @values = @{pop(@stack)};
+                next unless @values;
+                my $some_atom = "";
+                for my $value (@values) {
+                    if (!is_pair($value)) {
+                        $some_atom = 1;
+                        last;
+                    }
+                }
+                if ($some_atom) {
+                    my $car_values = $values[0];
+                    for my $value (@values) {
+                        if (!atoms_are_identical($value, $car_values)) {
+                            $ys = $bel->cdr($ys);
+                            next ELEMENT;
+                        }
+                    }
+                }
+                else {
+                    push @stack, [map { $bel->cdr($_) } @values];
+                    push @stack, [map { $bel->car($_) } @values];
+                }
+            }
+
+            return make_pair(
+                make_pair(
+                    make_symbol("xs"),
+                    $ys,
+                ),
+                make_pair(
+                    SYMBOL_D,
+                    SYMBOL_NIL,
+                ),
+            );
+        }
+    }
+
+    return SYMBOL_NIL;
+}
+
+sub fastfunc__in {
+    my ($bel, @args) = @_;
+
+    my $x = @args ? shift(@args) : SYMBOL_NIL;
+
+    ARG:
+    while (@args) {
+        my @stack = [$args[0], $x];
+        while (@stack) {
+            my @values = @{pop(@stack)};
+            next unless @values;
+            my $some_atom = "";
+            for my $value (@values) {
+                if (!is_pair($value)) {
+                    $some_atom = 1;
+                    last;
+                }
+            }
+            if ($some_atom) {
+                my $car_values = $values[0];
+                for my $value (@values) {
+                    if (!atoms_are_identical($value, $car_values)) {
+                        shift(@args);
+                        next ARG;
+                    }
+                }
+            }
+            else {
+                push @stack, [map { $bel->cdr($_) } @values];
+                push @stack, [map { $bel->car($_) } @values];
+            }
+        }
+        last ARG;
+    }
+
+    my $ys = SYMBOL_NIL;
+    while (@args) {
+        $ys = make_pair(pop(@args), $ys);
+    }
+    return $ys;
+}
+
+sub fastfunc__where__in {
+    my ($bel, @args) = @_;
+
+    my $x = @args ? shift(@args) : SYMBOL_NIL;
+
+    ARG:
+    while (@args) {
+        my @stack = [$args[0], $x];
+        while (@stack) {
+            my @values = @{pop(@stack)};
+            next unless @values;
+            my $some_atom = "";
+            for my $value (@values) {
+                if (!is_pair($value)) {
+                    $some_atom = 1;
+                    last;
+                }
+            }
+            if ($some_atom) {
+                my $car_values = $values[0];
+                for my $value (@values) {
+                    if (!atoms_are_identical($value, $car_values)) {
+                        shift(@args);
+                        next ARG;
+                    }
+                }
+            }
+            else {
+                push @stack, [map { $bel->cdr($_) } @values];
+                push @stack, [map { $bel->car($_) } @values];
+            }
+        }
+        last ARG;
+    }
+
+    my $ys = SYMBOL_NIL;
+    while (@args) {
+        $ys = make_pair(pop(@args), $ys);
+    }
+    return is_nil($ys) ? $ys : (
+        make_pair(
+            make_pair(make_symbol("xs"), $ys),
+            make_pair(SYMBOL_D, SYMBOL_NIL),
+        )
+    );
+}
+
+sub fastfunc__cadr {
+    my ($bel, $x) = @_;
+
+    return $bel->car($bel->cdr($x));
+}
+
+sub fastfunc__where__cadr {
+    my ($bel, $x) = @_;
+
+    return make_pair(
+        $bel->cdr($x),
+        make_pair(
+            SYMBOL_A,
+            SYMBOL_NIL,
+        ),
+    );
+}
+
+sub fastfunc__cddr {
+    my ($bel, $x) = @_;
+
+    return $bel->cdr($bel->cdr($x));
+}
+
+sub fastfunc__where__cddr {
+    my ($bel, $x) = @_;
+
+    return make_pair(
+        $bel->cdr($x),
+        make_pair(
+            SYMBOL_D,
+            SYMBOL_NIL,
+        ),
+    );
+}
+
+sub fastfunc__caddr {
+    my ($bel, $x) = @_;
+
+    return $bel->car($bel->cdr($bel->cdr($x)));
+}
+
+sub fastfunc__where__caddr {
+    my ($bel, $x) = @_;
+
+    return make_pair(
+        $bel->cdr($bel->cdr($x)),
+        make_pair(
+            SYMBOL_A,
+            SYMBOL_NIL,
+        ),
+    );
+}
+
+sub fastfunc__find {
+    my ($bel, $f, $xs) = @_;
+
+    while (!is_nil($xs)) {
+        my $value = $bel->car($xs);
+        if (!is_nil($bel->{call}->($f, $value))) {
+            return $value;
+        }
+        $xs = $bel->cdr($xs);
+    }
+    return SYMBOL_NIL;
+}
+
+sub fastfunc__where__find {
+    my ($bel, $f, $xs) = @_;
+
+    while (!is_nil($xs)) {
+        my $value = $bel->car($xs);
+        if (!is_nil($bel->{call}->($f, $value))) {
+            return make_pair(
+                $xs,
+                make_pair(
+                    SYMBOL_A,
+                    SYMBOL_NIL,
+                ),
+            );
+        }
+        $xs = $bel->cdr($xs);
+    }
+    return SYMBOL_NIL;
+}
+
+sub fastfunc__begins {
+    my ($bel, $xs, $pat, $f) = @_;
+
+    if (defined($f)) {
+        while (!is_nil($pat)) {
+            if (!is_pair($xs)) {
+                return SYMBOL_NIL;
+            }
+            else {
+                my $p = $bel->{call}->($f, $bel->car($xs), $bel->car($pat));
+                if (is_nil($p)) {
+                    return SYMBOL_NIL;
+                }
+            }
+            $xs = $bel->cdr($xs);
+            $pat = $bel->cdr($pat);
+        }
+    }
+    else {
+        while (!is_nil($pat)) {
+            if (!is_pair($xs)) {
+                return SYMBOL_NIL;
+            }
+
+            my @stack = [$bel->car($xs), $bel->car($pat)];
+            while (@stack) {
+                my @values = @{pop(@stack)};
+                next unless @values;
+                my $some_atom = "";
+                for my $value (@values) {
+                    if (!is_pair($value)) {
+                        $some_atom = 1;
+                        last;
+                    }
+                }
+                if ($some_atom) {
+                    my $car_values = $values[0];
+                    for my $value (@values) {
+                        if (!atoms_are_identical($value, $car_values)) {
+                            return SYMBOL_NIL;
+                        }
+                    }
+                }
+                else {
+                    push @stack, [map { $bel->cdr($_) } @values];
+                    push @stack, [map { $bel->car($_) } @values];
+                }
+            }
+
+            $xs = $bel->cdr($xs);
+            $pat = $bel->cdr($pat);
+        }
+    }
+
+    return SYMBOL_T;
+}
+
+sub fastfunc__caris {
+    my ($bel, $x, $y, $f) = @_;
+
+    if (!is_pair($x)) {
+        return SYMBOL_NIL;
+    }
+
+    if (defined($f)) {
+        return $bel->{call}->($f, $bel->car($x), $y);
+    }
+    else {
+        my @stack = [$bel->car($x), $y];
+        while (@stack) {
+            my @values = @{pop(@stack)};
+            next unless @values;
+            my $some_atom = "";
+            for my $value (@values) {
+                if (!is_pair($value)) {
+                    $some_atom = 1;
+                    last;
+                }
+            }
+            if ($some_atom) {
+                my $car_values = $values[0];
+                for my $value (@values) {
+                    if (!atoms_are_identical($value, $car_values)) {
+                        return SYMBOL_NIL;
+                    }
+                }
+            }
+            else {
+                push @stack, [map { $bel->cdr($_) } @values];
+                push @stack, [map { $bel->car($_) } @values];
+            }
+        }
+
+        return SYMBOL_T;
+    }
+}
+
+sub fastfunc__hug {
+    my ($bel, $xs, $f) = @_;
+
+    my @values;
+    my $cdr_xs;
+    if (defined($f)) {
+        while (!is_nil($cdr_xs = $bel->cdr($xs))) {
+            push @values, $bel->{call}->($f, $bel->car($xs), $bel->car($cdr_xs));
+            $xs = $bel->cdr($cdr_xs);
+        }
+        if (!is_nil($xs)) {
+            push @values, $bel->{call}->($f, $bel->car($xs));
+        }
+    }
+    else {
+        while (!is_nil($cdr_xs = $bel->cdr($xs))) {
+            push @values, make_pair(
+                $bel->car($xs),
+                make_pair(
+                    $bel->car($cdr_xs),
+                    SYMBOL_NIL));
+            $xs = $bel->cdr($cdr_xs);
+        }
+        if (!is_nil($xs)) {
+            push @values, make_pair($bel->car($xs), SYMBOL_NIL);
+        }
+    }
+
+    my $result = SYMBOL_NIL;
+    for my $value (reverse(@values)) {
+        $result = make_pair($value, $result);
+    }
+    return $result;
+}
+
+sub fastfunc__keep {
+    my ($bel, $f, $xs) = @_;
+
+    my @values;
+    while (!is_nil($xs)) {
+        my $value = $bel->car($xs);
+        if (!is_nil($bel->{call}->($f, $value))) {
+            push @values, $value;
+        }
+        $xs = $bel->cdr($xs);
+    }
+
+    my $result = SYMBOL_NIL;
+    for my $value (reverse(@values)) {
+        $result = make_pair($value, $result);
+    }
+    return $result;
+}
+
+sub fastfunc__rem {
+    my ($bel, $x, $ys, $f) = @_;
+
+    my @values;
+    if (defined($f)) {
+        while (!is_nil($ys)) {
+            my $value = $bel->car($ys);
+            if (is_nil($bel->{call}->($f, $value, $x))) {
+                push @values, $value;
+            }
+            $ys = $bel->cdr($ys);
+        }
+    }
+    else {
+        while (!is_nil($ys)) {
+            my $value = $bel->car($ys);
+            my @stack = [$x, $value];
+            while (@stack) {
+                my ($v0, $v1) = @{pop(@stack)};
+                if (!is_pair($v0) || !is_pair($v1)) {
+                    if (!atoms_are_identical($v0, $v1)) {
+                        push @values, $value;
+                        last;
+                    }
+                }
+                else {
+                    push @stack, [$bel->cdr($v0), $bel->cdr($v1)];
+                    push @stack, [$bel->car($v0), $bel->car($v1)];
+                }
+            }
+            $ys = $bel->cdr($ys);
+        }
+    }
+
+    my $result = SYMBOL_NIL;
+    for my $value (reverse(@values)) {
+        $result = make_pair($value, $result);
+    }
+    return $result;
+}
+
+sub fastfunc__get {
+    my ($bel, $k, $kvs, $f) = @_;
+
+    if (defined($f)) {
+        while (!is_nil($kvs)) {
+            my $kv = $bel->car($kvs);
+            if (!is_nil($bel->{call}->($f, $bel->car($kv), $k))) {
+                return $kv;
+            }
+            $kvs = $bel->cdr($kvs);
+        }
+    }
+    else {
+        ELEM:
+        while (!is_nil($kvs)) {
+            my $kv = $bel->car($kvs);
+            my @stack = [$bel->car($kv), $k];
+            while (@stack) {
+                my ($v0, $v1) = @{pop(@stack)};
+                if (!is_pair($v0) || !is_pair($v1)) {
+                    if (!atoms_are_identical($v0, $v1)) {
+                        $kvs = $bel->cdr($kvs);
+                        next ELEM;
+                    }
+                }
+                else {
+                    push @stack, [$bel->cdr($v0), $bel->cdr($v1)];
+                    push @stack, [$bel->car($v0), $bel->car($v1)];
+                }
+            }
+            return $kv;
+        }
+    }
+
+    return SYMBOL_NIL;
+}
+
+sub fastfunc__where__get {
+    my ($bel, $k, $kvs, $f) = @_;
+
+    if (defined($f)) {
+        while (!is_nil($kvs)) {
+            my $kv = $bel->car($kvs);
+            if (!is_nil($bel->{call}->($f, $bel->car($kv), $k))) {
+                return make_pair(
+                    $kvs,
+                    make_pair(
+                        SYMBOL_A,
+                        SYMBOL_NIL,
+                    ),
+                );
+            }
+            $kvs = $bel->cdr($kvs);
+        }
+    }
+    else {
+        ELEM:
+        while (!is_nil($kvs)) {
+            my $kv = $bel->car($kvs);
+            my @stack = [$bel->car($kv), $k];
+            while (@stack) {
+                my ($v0, $v1) = @{pop(@stack)};
+                if (!is_pair($v0) || !is_pair($v1)) {
+                    if (!atoms_are_identical($v0, $v1)) {
+                        $kvs = $bel->cdr($kvs);
+                        next ELEM;
+                    }
+                }
+                else {
+                    push @stack, [$bel->cdr($v0), $bel->cdr($v1)];
+                    push @stack, [$bel->car($v0), $bel->car($v1)];
+                }
+            }
+            return make_pair(
+                $kvs,
+                make_pair(
+                    SYMBOL_A,
+                    SYMBOL_NIL,
+                ),
+            );
+        }
+    }
+
+    return SYMBOL_NIL;
+}
+
+sub fastfunc__put {
+    my ($bel, $k, $v, $kvs, $f) = @_;
+
+    my @values = make_pair($k, $v);
+    if (defined($f)) {
+        while (!is_nil($kvs)) {
+            my $kv = $bel->car($kvs);
+            if (is_nil($bel->{call}->($f, $k, $bel->car($kv)))) {
+                push @values, $kv;
+            }
+            $kvs = $bel->cdr($kvs);
+        }
+    }
+    else {
+        while (!is_nil($kvs)) {
+            my $kv = $bel->car($kvs);
+            my @stack = [$k, $bel->car($kv)];
+            while (@stack) {
+                my ($v0, $v1) = @{pop(@stack)};
+                if (!is_pair($v0) || !is_pair($v1)) {
+                    if (!atoms_are_identical($v0, $v1)) {
+                        push @values, $kv;
+                        last;
+                    }
+                }
+                else {
+                    push @stack, [$bel->cdr($v0), $bel->cdr($v1)];
+                    push @stack, [$bel->car($v0), $bel->car($v1)];
+                }
+            }
+            $kvs = $bel->cdr($kvs);
+        }
+    }
+
+    my $result = SYMBOL_NIL;
+    for my $value (reverse(@values)) {
+        $result = make_pair($value, $result);
+    }
+    return $result;
+}
+
+sub fastfunc__rev {
+    my ($bel, $xs) = @_;
+
+    my $result = SYMBOL_NIL;
+    while (!is_nil($xs)) {
+        $result = make_pair($bel->car($xs), $result);
+        $xs = $bel->cdr($xs);
+    }
+
+    return $result;
+}
+
+sub fastfunc__snap {
+    my ($bel, $xs, $ys, $acc) = @_;
+
+    if (!defined($acc)) {
+        $acc = SYMBOL_NIL;
+    }
+
+    my @values;
+    while (!is_nil($acc)) {
+        push @values, $bel->car($acc);
+        $acc = $bel->cdr($acc);
+    }
+
+    while (!is_nil($xs)) {
+        push @values, $bel->car($ys);
+        $xs = $bel->cdr($xs);
+        $ys = $bel->cdr($ys);
+    }
+
+    my $result = SYMBOL_NIL;
+    for my $value (reverse(@values)) {
+        $result = make_pair($value, $result);
+    }
+
+    return make_pair(
+        $result,
+        make_pair(
+            $ys,
+            SYMBOL_NIL,
+        ),
+    );
+}
+
+sub fastfunc__udrop {
+    my ($bel, $xs, $ys) = @_;
+
+    while (!is_nil($xs)) {
+        $xs = $bel->cdr($xs);
+        $ys = $bel->cdr($ys);
+    }
+
+    return $ys;
+}
+
+sub fastfunc__idfn {
+    my ($bel, $x) = @_;
+
+    return $x;
+}
+
+sub fastfunc__where__idfn {
+    my ($bel, $x) = @_;
+
+    return make_pair(
+        make_pair(
+            make_symbol("x"),
+            $x,
+        ),
+        make_pair(
+            SYMBOL_D,
+            SYMBOL_NIL,
+        ),
+    );
+}
+
+sub fastfunc__pairwise {
+    my ($bel, $f, $xs) = @_;
+
+    my $cdr_xs;
+    while (!is_nil($cdr_xs = $bel->cdr($xs))) {
+        if (is_nil($bel->{call}->($f, $bel->car($xs), $bel->car($cdr_xs)))) {
+            return SYMBOL_NIL;
+        }
+        $xs = $cdr_xs;
+    }
+
+    return SYMBOL_T;
+}
+
+sub fastfunc__foldl {
+    my ($bel, $f, $base, @args) = @_;
+
+    return $base
+        unless @args;
+
+    while (!grep { is_nil($_) } @args) {
+        my @car_args = map { $bel->car($_) } @args;
+        $base = $bel->{call}->($f, @car_args, $base);
+        @args = map { $bel->cdr($_) } @args;
+    }
+
+    return $base;
+}
+
+sub fastfunc__foldr {
+    my ($bel, $f, $base, @args) = @_;
+
+    return $base
+        unless @args;
+
+    my @cars;
+    while (!grep { is_nil($_) } @args) {
+        push @cars, [map { $bel->car($_) } @args];
+        @args = map { $bel->cdr($_) } @args;
+    }
+
+    for my $cars (reverse(@cars)) {
+        $base = $bel->{call}->($f, @{$cars}, $base);
+    }
+
+    return $base;
+}
+
+sub fastfunc__fuse {
+    my ($bel, $f, @args) = @_;
+
+    return SYMBOL_NIL
+        unless @args;
+    my @sublists;
+    my $min_length = -1;
+    for my $list (@args) {
+        my @sublist;
+        while (!is_nil($list)) {
+            push @sublist, $bel->car($list);
+            $list = $bel->cdr($list);
+        }
+        push @sublists, \@sublist;
+        my $length = scalar(@sublist);
+        $min_length = $min_length == -1 || $length < $min_length
+            ? $length
+            : $min_length;
+    }
+    my @result;
+    for my $i (0..$min_length-1) {
+        push @result, $bel->{call}->(
+            $f,
+            map { $sublists[$_]->[$i] } 0..$#sublists
+        );
+    }
+    my $result = @result ? pop(@result) : SYMBOL_NIL;
+    while (@result) {
+        my $list = pop(@result);
+        my @values;
+        while (!is_nil($list)) {
+            push @values, $bel->car($list);
+            $list = $bel->cdr($list);
+        }
+        while (@values) {
+            my $value = pop(@values);
+            $result = make_pair($value, $result);
+        }
+    }
+
+    return $result;
+}
+
+sub fastfunc__match {
+    my ($bel, $x, $pat) = @_;
+
+    my @stack = [$x, $pat];
+    while (@stack) {
+        my ($v0, $v1) = @{pop(@stack)};
+        if (is_symbol_of_name($v1, "t")) {
+            # succeed
+        }
+        elsif (is_pair($v1)
+            && is_symbol_of_name($bel->car($v1), "lit")
+            && is_pair($bel->cdr($v1))
+            && (is_symbol_of_name($bel->car($bel->cdr($v1)), "prim")
+                || is_symbol_of_name($bel->car($bel->cdr($v1)), "clo"))) {
+            if (is_nil($bel->{call}->($v1, $v0))) {
+                return SYMBOL_NIL;
+            }
+        }
+        elsif (!is_pair($v0) || !is_pair($v1)) {
+            if (!atoms_are_identical($v0, $v1)) {
+                return SYMBOL_NIL;
+            }
+        }
+        else {
+            push @stack, [$bel->cdr($v0), $bel->cdr($v1)];
+            push @stack, [$bel->car($v0), $bel->car($v1)];
+        }
+    }
+
+    return SYMBOL_T;
+}
+
+sub fastfunc__split {
+    my ($bel, $f, $xs, $acc) = @_;
+
+    if (!defined($acc)) {
+        $acc = SYMBOL_NIL;
+    }
+    my @acc;
+    while (!is_nil($xs)) {
+        last
+            if !is_pair($xs) || !is_nil($bel->{call}->($f, $bel->car($xs)));
+        push(@acc, $bel->car($xs));
+        $xs = $bel->cdr($xs);
+    }
+
+    my @prefix;
+    while (!is_nil($acc)) {
+        push(@prefix, $bel->car($acc));
+        $acc = $bel->cdr($acc);
+    }
+    my $first = SYMBOL_NIL;
+    while (@acc) {
+        $first = make_pair(pop(@acc), $first);
+    }
+    while (@prefix) {
+        $first = make_pair(pop(@prefix), $first);
+    }
+    return make_pair(
+        $first,
+        make_pair(
+            $xs,
+            SYMBOL_NIL,
+        ),
+    );
+}
+
+sub fastfunc__i_lt {
+    my ($bel, $xs, $ys) = @_;
+
+    while (!is_nil($xs)) {
+        $xs = $bel->cdr($xs);
+        $ys = $bel->cdr($ys);
+    }
+
+    return $ys;
+}
+
+sub fastfunc__i_plus {
+    my ($bel, @args) = @_;
+
+    my $result = @args ? pop(@args) : SYMBOL_NIL;
+    while (@args) {
+        my $list = pop(@args);
+        my @values;
+        while (!is_nil($list)) {
+            push @values, $bel->car($list);
+            $list = $bel->cdr($list);
+        }
+        while (@values) {
+            my $value = pop(@values);
+            $result = make_pair($value, $result);
+        }
+    }
+
+    return $result;
+}
+
+sub fastfunc__i_minus {
+    my ($bel, $x, $y) = @_;
+
+    while (!is_nil($x)) {
+        if (is_nil($y)) {
+            return make_pair(
+                make_symbol("+"),
+                make_pair(
+                    $x,
+                    SYMBOL_NIL,
+                ),
+            );
+        }
+
+        $x = $bel->cdr($x);
+        $y = $bel->cdr($y);
+    }
+
+    return make_pair(
+        make_symbol("-"),
+        make_pair(
+            $y,
+            SYMBOL_NIL,
+        ),
+    );
+}
+
+sub fastfunc__i_star {
+    my ($bel, @args) = @_;
+
+    my $product = 1;
+    for my $arg (@args) {
+        my $factor = 0;
+        while (!is_nil($arg)) {
+            $factor += 1;
+            $arg = $bel->cdr($arg);
+        }
+        $product *= $factor;
+    }
+
+    my $result = SYMBOL_NIL;
+    for (1..$product) {
+        $result = make_pair(SYMBOL_T, $result);
+    }
+    return $result;
+}
+
+sub fastfunc__i_slash {
+    my ($bel, $x, $y, $q) = @_;
+
+    if (!defined($q)) {
+        $q = SYMBOL_NIL;
+    }
+
+    my $xn = 0;
+    while (!is_nil($x)) {
+        $xn += 1;
+        $x = $bel->cdr($x);
+    }
+
+    my $yn = 0;
+    while (!is_nil($y)) {
+        $yn += 1;
+        $y = $bel->cdr($y);
+    }
+
+    my $n = int($xn / $yn);
+    for (1..$n) {
+        $q = make_pair(SYMBOL_T, $q);
+    }
+
+    my $m = $xn % $yn;
+    my $remainder = SYMBOL_NIL;
+    for (1..$m) {
+        $remainder = make_pair(SYMBOL_T, $remainder);
+    }
+
+    return make_pair(
+        $q,
+        make_pair(
+            $remainder,
+            SYMBOL_NIL,
+        ),
+    );
+}
+
+sub fastfunc__i_hat {
+    my ($bel, $x, $y) = @_;
+
+    my $xn = 0;
+    while (!is_nil($x)) {
+        $xn += 1;
+        $x = $bel->cdr($x);
+    }
+
+    my $yn = 0;
+    while (!is_nil($y)) {
+        $yn += 1;
+        $y = $bel->cdr($y);
+    }
+
+    my $n = $xn ** $yn;
+
+    my $result = SYMBOL_NIL;
+    for (1..$n) {
+        $result = make_pair(SYMBOL_T, $result);
+    }
+    return $result;
+}
+
+sub fastfunc__r_plus {
+    my ($bel, $x, $y) = @_;
+
+    my $xn = $bel->car($x);
+    my $xd = $bel->car($bel->cdr($x));
+
+    my $yn = $bel->car($y);
+    my $yd = $bel->car($bel->cdr($y));
+
+    my $xn_n = 0;
+    while (!is_nil($xn)) {
+        ++$xn_n;
+        $xn = $bel->cdr($xn);
+    }
+
+    my $xd_n = 0;
+    while (!is_nil($xd)) {
+        ++$xd_n;
+        $xd = $bel->cdr($xd);
+    }
+
+    my $yn_n = 0;
+    while (!is_nil($yn)) {
+        ++$yn_n;
+        $yn = $bel->cdr($yn);
+    }
+
+    my $yd_n = 0;
+    while (!is_nil($yd)) {
+        ++$yd_n;
+        $yd = $bel->cdr($yd);
+    }
+
+    my $n_n = $xn_n * $yd_n + $yn_n * $xd_n;
+    my $d_n = $xd_n * $yd_n;
+
+    my $n = SYMBOL_NIL;
+    for (1..$n_n) {
+        $n = make_pair(
+            SYMBOL_T,
+            $n,
+        );
+    }
+
+    my $d = SYMBOL_NIL;
+    for (1..$d_n) {
+        $d = make_pair(
+            SYMBOL_T,
+            $d,
+        );
+    }
+
+    return make_pair(
+        $n,
+        make_pair(
+            $d,
+            SYMBOL_NIL,
+        ),
+    );
+}
+
+sub fastfunc__r_minus {
+    my ($bel, $x, $y) = @_;
+
+    my $xn = $bel->car($x);
+    my $xd = $bel->car($bel->cdr($x));
+
+    my $yn = $bel->car($y);
+    my $yd = $bel->car($bel->cdr($y));
+
+    my $xn_n = 0;
+    while (!is_nil($xn)) {
+        ++$xn_n;
+        $xn = $bel->cdr($xn);
+    }
+
+    my $xd_n = 0;
+    while (!is_nil($xd)) {
+        ++$xd_n;
+        $xd = $bel->cdr($xd);
+    }
+
+    my $yn_n = 0;
+    while (!is_nil($yn)) {
+        ++$yn_n;
+        $yn = $bel->cdr($yn);
+    }
+
+    my $yd_n = 0;
+    while (!is_nil($yd)) {
+        ++$yd_n;
+        $yd = $bel->cdr($yd);
+    }
+
+    my $n_n = $xn_n * $yd_n - $yn_n * $xd_n;
+    my $sign = $n_n < 1 ? "-" : "+";
+    $n_n = abs($n_n);
+    my $d_n = $xd_n * $yd_n;
+
+    my $n = SYMBOL_NIL;
+    for (1..$n_n) {
+        $n = make_pair(
+            SYMBOL_T,
+            $n,
+        );
+    }
+
+    my $d = SYMBOL_NIL;
+    for (1..$d_n) {
+        $d = make_pair(
+            SYMBOL_T,
+            $d,
+        );
+    }
+
+    return make_pair(
+        make_symbol($sign),
+        make_pair(
+            $n,
+            make_pair(
+                $d,
+                SYMBOL_NIL,
+            ),
+        ),
+    );
+}
+
+sub fastfunc__r_star {
+    my ($bel, $x, $y) = @_;
+
+    my $xn = $bel->car($x);
+    my $xd = $bel->car($bel->cdr($x));
+
+    my $yn = $bel->car($y);
+    my $yd = $bel->car($bel->cdr($y));
+
+    my $xn_n = 0;
+    while (!is_nil($xn)) {
+        ++$xn_n;
+        $xn = $bel->cdr($xn);
+    }
+
+    my $xd_n = 0;
+    while (!is_nil($xd)) {
+        ++$xd_n;
+        $xd = $bel->cdr($xd);
+    }
+
+    my $yn_n = 0;
+    while (!is_nil($yn)) {
+        ++$yn_n;
+        $yn = $bel->cdr($yn);
+    }
+
+    my $yd_n = 0;
+    while (!is_nil($yd)) {
+        ++$yd_n;
+        $yd = $bel->cdr($yd);
+    }
+
+    my $n_n = $xn_n * $yn_n;
+    my $d_n = $xd_n * $yd_n;
+
+    my $n = SYMBOL_NIL;
+    for (1..$n_n) {
+        $n = make_pair(
+            SYMBOL_T,
+            $n,
+        );
+    }
+
+    my $d = SYMBOL_NIL;
+    for (1..$d_n) {
+        $d = make_pair(
+            SYMBOL_T,
+            $d,
+        );
+    }
+
+    return make_pair(
+        $n,
+        make_pair(
+            $d,
+            SYMBOL_NIL,
+        ),
+    );
+}
+
+sub fastfunc__r_slash {
+    my ($bel, $x, $y) = @_;
+
+    my $xn = $bel->car($x);
+    my $xd = $bel->car($bel->cdr($x));
+
+    my $yn = $bel->car($y);
+    my $yd = $bel->car($bel->cdr($y));
+
+    my $xn_n = 0;
+    while (!is_nil($xn)) {
+        ++$xn_n;
+        $xn = $bel->cdr($xn);
+    }
+
+    my $xd_n = 0;
+    while (!is_nil($xd)) {
+        ++$xd_n;
+        $xd = $bel->cdr($xd);
+    }
+
+    my $yn_n = 0;
+    while (!is_nil($yn)) {
+        ++$yn_n;
+        $yn = $bel->cdr($yn);
+    }
+
+    my $yd_n = 0;
+    while (!is_nil($yd)) {
+        ++$yd_n;
+        $yd = $bel->cdr($yd);
+    }
+
+    my $n_n = $xn_n * $yd_n;
+    my $d_n = $xd_n * $yn_n;
+
+    my $n = SYMBOL_NIL;
+    for (1..$n_n) {
+        $n = make_pair(
+            SYMBOL_T,
+            $n,
+        );
+    }
+
+    my $d = SYMBOL_NIL;
+    for (1..$d_n) {
+        $d = make_pair(
+            SYMBOL_T,
+            $d,
+        );
+    }
+
+    return make_pair(
+        $n,
+        make_pair(
+            $d,
+            SYMBOL_NIL,
+        ),
+    );
+}
+
+sub fastfunc__sr_plus {
+    my ($bel, $x, $y) = @_;
+
+    my $xs = $bel->car($x);
+    my $xn = $bel->car($bel->cdr($x));
+    my $xd = $bel->car($bel->cdr($bel->cdr($x)));
+
+    my $ys = $bel->car($y);
+    my $yn = $bel->car($bel->cdr($y));
+    my $yd = $bel->car($bel->cdr($bel->cdr($y)));
+
+    my $symbol;
+    if (is_symbol_of_name($xs, "-")) {
+        if (is_symbol_of_name($ys, "-")) {
+            my $xn_n = 0;
+            while (!is_nil($xn)) {
+                ++$xn_n;
+                $xn = $bel->cdr($xn);
+            }
+
+            my $xd_n = 0;
+            while (!is_nil($xd)) {
+                ++$xd_n;
+                $xd = $bel->cdr($xd);
+            }
+
+            my $yn_n = 0;
+            while (!is_nil($yn)) {
+                ++$yn_n;
+                $yn = $bel->cdr($yn);
+            }
+
+            my $yd_n = 0;
+            while (!is_nil($yd)) {
+                ++$yd_n;
+                $yd = $bel->cdr($yd);
+            }
+
+            my $n_n = $xn_n * $yd_n + $yn_n * $xd_n;
+            my $d_n = $xd_n * $yd_n;
+
+            my $n = SYMBOL_NIL;
+            for (1..$n_n) {
+                $n = make_pair(
+                    SYMBOL_T,
+                    $n,
+                );
+            }
+
+            my $d = SYMBOL_NIL;
+            for (1..$d_n) {
+                $d = make_pair(
+                    SYMBOL_T,
+                    $d,
+                );
+            }
+
+            return make_pair(
+                make_symbol("-"),
+                make_pair(
+                    $n,
+                    make_pair(
+                        $d,
+                        SYMBOL_NIL,
+                    ),
+                ),
+            );
+        }
+        else {
+            my $xn_n = 0;
+            while (!is_nil($xn)) {
+                ++$xn_n;
+                $xn = $bel->cdr($xn);
+            }
+
+            my $xd_n = 0;
+            while (!is_nil($xd)) {
+                ++$xd_n;
+                $xd = $bel->cdr($xd);
+            }
+
+            my $yn_n = 0;
+            while (!is_nil($yn)) {
+                ++$yn_n;
+                $yn = $bel->cdr($yn);
+            }
+
+            my $yd_n = 0;
+            while (!is_nil($yd)) {
+                ++$yd_n;
+                $yd = $bel->cdr($yd);
+            }
+
+            my $n_n = $yn_n * $xd_n - $xn_n * $yd_n;
+            my $sign = $n_n < 1 ? "-" : "+";
+            $n_n = abs($n_n);
+            my $d_n = $yd_n * $xd_n;
+
+            my $n = SYMBOL_NIL;
+            for (1..$n_n) {
+                $n = make_pair(
+                    SYMBOL_T,
+                    $n,
+                );
+            }
+
+            my $d = SYMBOL_NIL;
+            for (1..$d_n) {
+                $d = make_pair(
+                    SYMBOL_T,
+                    $d,
+                );
+            }
+
+            return make_pair(
+                make_symbol($sign),
+                make_pair(
+                    $n,
+                    make_pair(
+                        $d,
+                        SYMBOL_NIL,
+                    ),
+                ),
+            );
+        }
+    }
+    else {
+        if (is_symbol_of_name($ys, "-")) {
+            my $xn_n = 0;
+            while (!is_nil($xn)) {
+                ++$xn_n;
+                $xn = $bel->cdr($xn);
+            }
+
+            my $xd_n = 0;
+            while (!is_nil($xd)) {
+                ++$xd_n;
+                $xd = $bel->cdr($xd);
+            }
+
+            my $yn_n = 0;
+            while (!is_nil($yn)) {
+                ++$yn_n;
+                $yn = $bel->cdr($yn);
+            }
+
+            my $yd_n = 0;
+            while (!is_nil($yd)) {
+                ++$yd_n;
+                $yd = $bel->cdr($yd);
+            }
+
+            my $n_n = $xn_n * $yd_n - $yn_n * $xd_n;
+            my $sign = $n_n < 1 ? "-" : "+";
+            $n_n = abs($n_n);
+            my $d_n = $xd_n * $yd_n;
+
+            my $n = SYMBOL_NIL;
+            for (1..$n_n) {
+                $n = make_pair(
+                    SYMBOL_T,
+                    $n,
+                );
+            }
+
+            my $d = SYMBOL_NIL;
+            for (1..$d_n) {
+                $d = make_pair(
+                    SYMBOL_T,
+                    $d,
+                );
+            }
+
+            return make_pair(
+                make_symbol($sign),
+                make_pair(
+                    $n,
+                    make_pair(
+                        $d,
+                        SYMBOL_NIL,
+                    ),
+                ),
+            );
+        }
+        else {
+            my $xn_n = 0;
+            while (!is_nil($xn)) {
+                ++$xn_n;
+                $xn = $bel->cdr($xn);
+            }
+
+            my $xd_n = 0;
+            while (!is_nil($xd)) {
+                ++$xd_n;
+                $xd = $bel->cdr($xd);
+            }
+
+            my $yn_n = 0;
+            while (!is_nil($yn)) {
+                ++$yn_n;
+                $yn = $bel->cdr($yn);
+            }
+
+            my $yd_n = 0;
+            while (!is_nil($yd)) {
+                ++$yd_n;
+                $yd = $bel->cdr($yd);
+            }
+
+            my $n_n = $xn_n * $yd_n + $yn_n * $xd_n;
+            my $d_n = $xd_n * $yd_n;
+
+            my $n = SYMBOL_NIL;
+            for (1..$n_n) {
+                $n = make_pair(
+                    SYMBOL_T,
+                    $n,
+                );
+            }
+
+            my $d = SYMBOL_NIL;
+            for (1..$d_n) {
+                $d = make_pair(
+                    SYMBOL_T,
+                    $d,
+                );
+            }
+
+            return make_pair(
+                make_symbol("+"),
+                make_pair(
+                    $n,
+                    make_pair(
+                        $d,
+                        SYMBOL_NIL,
+                    ),
+                ),
+            );
+        }
+    }
+}
+
+sub fastfunc__sr_minus {
+    my ($bel, $x, $y) = @_;
+
+    my $xs = $bel->car($x);
+    my $xn = $bel->car($bel->cdr($x));
+    my $xd = $bel->car($bel->cdr($bel->cdr($x)));
+
+    my $ys = $bel->car($y);
+    my $yn = $bel->car($bel->cdr($y));
+    my $yd = $bel->car($bel->cdr($bel->cdr($y)));
+
+    my $symbol;
+    if (is_symbol_of_name($xs, "-")) {
+        if (is_symbol_of_name($ys, "-")) {
+            my $xn_n = 0;
+            while (!is_nil($xn)) {
+                ++$xn_n;
+                $xn = $bel->cdr($xn);
+            }
+
+            my $xd_n = 0;
+            while (!is_nil($xd)) {
+                ++$xd_n;
+                $xd = $bel->cdr($xd);
+            }
+
+            my $yn_n = 0;
+            while (!is_nil($yn)) {
+                ++$yn_n;
+                $yn = $bel->cdr($yn);
+            }
+
+            my $yd_n = 0;
+            while (!is_nil($yd)) {
+                ++$yd_n;
+                $yd = $bel->cdr($yd);
+            }
+
+            my $n_n = $yn_n * $xd_n - $xn_n * $yd_n;
+            my $sign = $n_n < 1 ? "-" : "+";
+            $n_n = abs($n_n);
+            my $d_n = $yd_n * $xd_n;
+
+            my $n = SYMBOL_NIL;
+            for (1..$n_n) {
+                $n = make_pair(
+                    SYMBOL_T,
+                    $n,
+                );
+            }
+
+            my $d = SYMBOL_NIL;
+            for (1..$d_n) {
+                $d = make_pair(
+                    SYMBOL_T,
+                    $d,
+                );
+            }
+
+            return make_pair(
+                make_symbol($sign),
+                make_pair(
+                    $n,
+                    make_pair(
+                        $d,
+                        SYMBOL_NIL,
+                    ),
+                ),
+            );
+        }
+        else {
+            my $xn_n = 0;
+            while (!is_nil($xn)) {
+                ++$xn_n;
+                $xn = $bel->cdr($xn);
+            }
+
+            my $xd_n = 0;
+            while (!is_nil($xd)) {
+                ++$xd_n;
+                $xd = $bel->cdr($xd);
+            }
+
+            my $yn_n = 0;
+            while (!is_nil($yn)) {
+                ++$yn_n;
+                $yn = $bel->cdr($yn);
+            }
+
+            my $yd_n = 0;
+            while (!is_nil($yd)) {
+                ++$yd_n;
+                $yd = $bel->cdr($yd);
+            }
+
+            my $n_n = $xn_n * $yd_n + $yn_n * $xd_n;
+            my $d_n = $xd_n * $yd_n;
+
+            my $n = SYMBOL_NIL;
+            for (1..$n_n) {
+                $n = make_pair(
+                    SYMBOL_T,
+                    $n,
+                );
+            }
+
+            my $d = SYMBOL_NIL;
+            for (1..$d_n) {
+                $d = make_pair(
+                    SYMBOL_T,
+                    $d,
+                );
+            }
+
+            return make_pair(
+                make_symbol("-"),
+                make_pair(
+                    $n,
+                    make_pair(
+                        $d,
+                        SYMBOL_NIL,
+                    ),
+                ),
+            );
+        }
+    }
+    else {
+        if (is_symbol_of_name($ys, "-")) {
+            my $xn_n = 0;
+            while (!is_nil($xn)) {
+                ++$xn_n;
+                $xn = $bel->cdr($xn);
+            }
+
+            my $xd_n = 0;
+            while (!is_nil($xd)) {
+                ++$xd_n;
+                $xd = $bel->cdr($xd);
+            }
+
+            my $yn_n = 0;
+            while (!is_nil($yn)) {
+                ++$yn_n;
+                $yn = $bel->cdr($yn);
+            }
+
+            my $yd_n = 0;
+            while (!is_nil($yd)) {
+                ++$yd_n;
+                $yd = $bel->cdr($yd);
+            }
+
+            my $n_n = $xn_n * $yd_n + $yn_n * $xd_n;
+            my $d_n = $xd_n * $yd_n;
+
+            my $n = SYMBOL_NIL;
+            for (1..$n_n) {
+                $n = make_pair(
+                    SYMBOL_T,
+                    $n,
+                );
+            }
+
+            my $d = SYMBOL_NIL;
+            for (1..$d_n) {
+                $d = make_pair(
+                    SYMBOL_T,
+                    $d,
+                );
+            }
+
+            return make_pair(
+                make_symbol("+"),
+                make_pair(
+                    $n,
+                    make_pair(
+                        $d,
+                        SYMBOL_NIL,
+                    ),
+                ),
+            );
+        }
+        else {
+            my $xn_n = 0;
+            while (!is_nil($xn)) {
+                ++$xn_n;
+                $xn = $bel->cdr($xn);
+            }
+
+            my $xd_n = 0;
+            while (!is_nil($xd)) {
+                ++$xd_n;
+                $xd = $bel->cdr($xd);
+            }
+
+            my $yn_n = 0;
+            while (!is_nil($yn)) {
+                ++$yn_n;
+                $yn = $bel->cdr($yn);
+            }
+
+            my $yd_n = 0;
+            while (!is_nil($yd)) {
+                ++$yd_n;
+                $yd = $bel->cdr($yd);
+            }
+
+            my $n_n = $xn_n * $yd_n - $yn_n * $xd_n;
+            my $sign = $n_n < 1 && $yn_n > 0 ? "-" : "+";
+            $n_n = abs($n_n);
+            my $d_n = $xd_n * $yd_n;
+
+            my $n = SYMBOL_NIL;
+            for (1..$n_n) {
+                $n = make_pair(
+                    SYMBOL_T,
+                    $n,
+                );
+            }
+
+            my $d = SYMBOL_NIL;
+            for (1..$d_n) {
+                $d = make_pair(
+                    SYMBOL_T,
+                    $d,
+                );
+            }
+
+            return make_pair(
+                make_symbol($sign),
+                make_pair(
+                    $n,
+                    make_pair(
+                        $d,
+                        SYMBOL_NIL,
+                    ),
+                ),
+            );
+        }
+    }
+}
+
+sub fastfunc__srinv {
+    my ($bel, $sr) = @_;
+
+    my $s = $bel->car($sr);
+    my $n = $bel->car($bel->cdr($sr));
+    my $d = $bel->car($bel->cdr($bel->cdr($sr)));
+
+    my $sign = is_symbol_of_name($s, "+") && !is_nil($n)
+        ? "-"
+        : "+";
+
+    return make_pair(
+        make_symbol($sign),
+        make_pair(
+            $n,
+            make_pair(
+                $d,
+                SYMBOL_NIL,
+            ),
+        ),
+    );
+}
+
+sub fastfunc__sr_star {
+    my ($bel, $x, $y) = @_;
+
+    my $xs = $bel->car($x);
+    my $xn = $bel->car($bel->cdr($x));
+    my $xd = $bel->car($bel->cdr($bel->cdr($x)));
+
+    my $ys = $bel->car($y);
+    my $yn = $bel->car($bel->cdr($y));
+    my $yd = $bel->car($bel->cdr($bel->cdr($y)));
+
+    my $sign = is_symbol_of_name($xs, "-")
+        ? make_symbol(is_symbol_of_name($ys, "-") ? "+" : "-")
+        : $ys;
+
+    my $xn_n = 0;
+    while (!is_nil($xn)) {
+        ++$xn_n;
+        $xn = $bel->cdr($xn);
+    }
+
+    my $xd_n = 0;
+    while (!is_nil($xd)) {
+        ++$xd_n;
+        $xd = $bel->cdr($xd);
+    }
+
+    my $yn_n = 0;
+    while (!is_nil($yn)) {
+        ++$yn_n;
+        $yn = $bel->cdr($yn);
+    }
+
+    my $yd_n = 0;
+    while (!is_nil($yd)) {
+        ++$yd_n;
+        $yd = $bel->cdr($yd);
+    }
+
+    my $n_n = $xn_n * $yn_n;
+    my $d_n = $xd_n * $yd_n;
+
+    my $n = SYMBOL_NIL;
+    for (1..$n_n) {
+        $n = make_pair(
+            SYMBOL_T,
+            $n,
+        );
+    }
+
+    my $d = SYMBOL_NIL;
+    for (1..$d_n) {
+        $d = make_pair(
+            SYMBOL_T,
+            $d,
+        );
+    }
+
+    return make_pair(
+        $sign,
+        make_pair(
+            $n,
+            make_pair(
+                $d,
+                SYMBOL_NIL,
+            ),
+        ),
+    );
+}
+
+sub fastfunc__sr_slash {
+    my ($bel, $x, $y) = @_;
+
+    my $xs = $bel->car($x);
+    my $xn = $bel->car($bel->cdr($x));
+    my $xd = $bel->car($bel->cdr($bel->cdr($x)));
+
+    my $ys = $bel->car($y);
+    my $yn = $bel->car($bel->cdr($y));
+    my $yd = $bel->car($bel->cdr($bel->cdr($y)));
+
+    die "'mistype\n"
+        if is_nil($yn);
+
+    my $sign = is_symbol_of_name($xs, "-")
+        ? make_symbol(is_symbol_of_name($ys, "-") ? "+" : "-")
+        : $ys;
+
+    my $xn_n = 0;
+    while (!is_nil($xn)) {
+        ++$xn_n;
+        $xn = $bel->cdr($xn);
+    }
+
+    my $xd_n = 0;
+    while (!is_nil($xd)) {
+        ++$xd_n;
+        $xd = $bel->cdr($xd);
+    }
+
+    my $yn_n = 0;
+    while (!is_nil($yn)) {
+        ++$yn_n;
+        $yn = $bel->cdr($yn);
+    }
+
+    my $yd_n = 0;
+    while (!is_nil($yd)) {
+        ++$yd_n;
+        $yd = $bel->cdr($yd);
+    }
+
+    my $n_n = $xn_n * $yd_n;
+    my $d_n = $xd_n * $yn_n;
+
+    my $n = SYMBOL_NIL;
+    for (1..$n_n) {
+        $n = make_pair(
+            SYMBOL_T,
+            $n,
+        );
+    }
+
+    my $d = SYMBOL_NIL;
+    for (1..$d_n) {
+        $d = make_pair(
+            SYMBOL_T,
+            $d,
+        );
+    }
+
+    return make_pair(
+        $sign,
+        make_pair(
+            $n,
+            make_pair(
+                $d,
+                SYMBOL_NIL,
+            ),
+        ),
+    );
+}
+
+sub fastfunc__srrecip {
+    my ($bel, $sr) = @_;
+
+    my $s = $bel->car($sr);
+    my $n = $bel->car($bel->cdr($sr));
+    die "'mistype\n"
+        if is_nil($n);
+    my $d = $bel->car($bel->cdr($bel->cdr($sr)));
+
+    return make_pair(
+        $s,
+        make_pair(
+            $d,
+            make_pair(
+                $n,
+                SYMBOL_NIL,
+            ),
+        ),
+    );
+}
+
+sub fastfunc__sr_lt {
+    my ($bel, $x, $y) = @_;
+
+    my $xs = $bel->car($x);
+    my $xn = $bel->car($bel->cdr($x));
+    my $xd = $bel->car($bel->cdr($bel->cdr($x)));
+
+    my $ys = $bel->car($y);
+    my $yn = $bel->car($bel->cdr($y));
+    my $yd = $bel->car($bel->cdr($bel->cdr($y)));
+
+    if (is_symbol_of_name($xs, "+")) {
+        if (is_symbol_of_name($ys, "+")) {
+            my $xn_n = 0;
+            while (!is_nil($xn)) {
+                ++$xn_n;
+                $xn = $bel->cdr($xn);
+            }
+
+            my $xd_n = 0;
+            while (!is_nil($xd)) {
+                ++$xd_n;
+                $xd = $bel->cdr($xd);
+            }
+
+            my $yn_n = 0;
+            while (!is_nil($yn)) {
+                ++$yn_n;
+                $yn = $bel->cdr($yn);
+            }
+
+            my $yd_n = 0;
+            while (!is_nil($yd)) {
+                ++$yd_n;
+                $yd = $bel->cdr($yd);
+            }
+
+            my $p1_n = $xn_n * $yd_n;
+            my $p2_n = $yn_n * $xd_n;
+
+            my $n = $p2_n - $p1_n;
+            my $result = SYMBOL_NIL;
+            for (1..$n) {
+                $result = make_pair(SYMBOL_T, $result);
+            }
+            return $result;
+        }
+        else {
+            return SYMBOL_NIL;
+        }
+    }
+    else {
+        if (is_symbol_of_name($ys, "+")) {
+            return !is_nil($xn) || !is_nil($yn)
+                ? SYMBOL_T
+                : SYMBOL_NIL;
+        }
+        else {
+            my $xn_n = 0;
+            while (!is_nil($xn)) {
+                ++$xn_n;
+                $xn = $bel->cdr($xn);
+            }
+
+            my $xd_n = 0;
+            while (!is_nil($xd)) {
+                ++$xd_n;
+                $xd = $bel->cdr($xd);
+            }
+
+            my $yn_n = 0;
+            while (!is_nil($yn)) {
+                ++$yn_n;
+                $yn = $bel->cdr($yn);
+            }
+
+            my $yd_n = 0;
+            while (!is_nil($yd)) {
+                ++$yd_n;
+                $yd = $bel->cdr($yd);
+            }
+
+            my $p1_n = $yn_n * $xd_n;
+            my $p2_n = $xn_n * $yd_n;
+
+            my $n = $p2_n - $p1_n;
+            my $result = SYMBOL_NIL;
+            for (1..$n) {
+                $result = make_pair(SYMBOL_T, $result);
+            }
+            return $result;
+        }
+    }
+}
+
+sub fastfunc__srnum {
+    my ($bel, $x) = @_;
+
+    return $bel->car($bel->cdr($x));
+}
+
+sub fastfunc__where__srnum {
+    my ($bel, $x) = @_;
+
+    return make_pair(
+        $bel->cdr($x),
+        make_pair(
+            SYMBOL_A,
+            SYMBOL_NIL,
+        ),
+    );
+}
+
+sub fastfunc__srden {
+    my ($bel, $x) = @_;
+
+    return $bel->car($bel->cdr($bel->cdr($x)));
+}
+
+sub fastfunc__where__srden {
+    my ($bel, $x) = @_;
+
+    return make_pair(
+        $bel->cdr($bel->cdr($x)),
+        make_pair(
+            SYMBOL_A,
+            SYMBOL_NIL,
+        ),
+    );
+}
+
+sub fastfunc__c_plus {
+    my ($bel, $x, $y) = @_;
+
+    my $xr = $bel->car($x);
+    my $xi = $bel->car($bel->cdr($x));
+
+    my $yr = $bel->car($y);
+    my $yi = $bel->car($bel->cdr($y));
+
+    my $real_part;
+    {
+        my $xs = $bel->car($xr);
+        my $xn = $bel->car($bel->cdr($xr));
+        my $xd = $bel->car($bel->cdr($bel->cdr($xr)));
+
+        my $ys = $bel->car($yr);
+        my $yn = $bel->car($bel->cdr($yr));
+        my $yd = $bel->car($bel->cdr($bel->cdr($yr)));
+
+        my $symbol;
+        if (is_symbol_of_name($xs, "-")) {
+            if (is_symbol_of_name($ys, "-")) {
+                my $xn_n = 0;
+                while (!is_nil($xn)) {
+                    ++$xn_n;
+                    $xn = $bel->cdr($xn);
+                }
+
+                my $xd_n = 0;
+                while (!is_nil($xd)) {
+                    ++$xd_n;
+                    $xd = $bel->cdr($xd);
+                }
+
+                my $yn_n = 0;
+                while (!is_nil($yn)) {
+                    ++$yn_n;
+                    $yn = $bel->cdr($yn);
+                }
+
+                my $yd_n = 0;
+                while (!is_nil($yd)) {
+                    ++$yd_n;
+                    $yd = $bel->cdr($yd);
+                }
+
+                my $n_n = $xn_n * $yd_n + $yn_n * $xd_n;
+                my $d_n = $xd_n * $yd_n;
+
+                my $n = SYMBOL_NIL;
+                for (1..$n_n) {
+                    $n = make_pair(
+                        SYMBOL_T,
+                        $n,
+                    );
+                }
+
+                my $d = SYMBOL_NIL;
+                for (1..$d_n) {
+                    $d = make_pair(
+                        SYMBOL_T,
+                        $d,
+                    );
+                }
+
+                $real_part = make_pair(
+                    make_symbol("-"),
+                    make_pair(
+                        $n,
+                        make_pair(
+                            $d,
+                            SYMBOL_NIL,
+                        ),
+                    ),
+                );
+            }
+            else {
+                my $xn_n = 0;
+                while (!is_nil($xn)) {
+                    ++$xn_n;
+                    $xn = $bel->cdr($xn);
+                }
+
+                my $xd_n = 0;
+                while (!is_nil($xd)) {
+                    ++$xd_n;
+                    $xd = $bel->cdr($xd);
+                }
+
+                my $yn_n = 0;
+                while (!is_nil($yn)) {
+                    ++$yn_n;
+                    $yn = $bel->cdr($yn);
+                }
+
+                my $yd_n = 0;
+                while (!is_nil($yd)) {
+                    ++$yd_n;
+                    $yd = $bel->cdr($yd);
+                }
+
+                my $n_n = $yn_n * $xd_n - $xn_n * $yd_n;
+                my $sign = $n_n < 1 ? "-" : "+";
+                $n_n = abs($n_n);
+                my $d_n = $yd_n * $xd_n;
+
+                my $n = SYMBOL_NIL;
+                for (1..$n_n) {
+                    $n = make_pair(
+                        SYMBOL_T,
+                        $n,
+                    );
+                }
+
+                my $d = SYMBOL_NIL;
+                for (1..$d_n) {
+                    $d = make_pair(
+                        SYMBOL_T,
+                        $d,
+                    );
+                }
+
+                $real_part = make_pair(
+                    make_symbol($sign),
+                    make_pair(
+                        $n,
+                        make_pair(
+                            $d,
+                            SYMBOL_NIL,
+                        ),
+                    ),
+                );
+            }
+        }
+        else {
+            if (is_symbol_of_name($ys, "-")) {
+                my $xn_n = 0;
+                while (!is_nil($xn)) {
+                    ++$xn_n;
+                    $xn = $bel->cdr($xn);
+                }
+
+                my $xd_n = 0;
+                while (!is_nil($xd)) {
+                    ++$xd_n;
+                    $xd = $bel->cdr($xd);
+                }
+
+                my $yn_n = 0;
+                while (!is_nil($yn)) {
+                    ++$yn_n;
+                    $yn = $bel->cdr($yn);
+                }
+
+                my $yd_n = 0;
+                while (!is_nil($yd)) {
+                    ++$yd_n;
+                    $yd = $bel->cdr($yd);
+                }
+
+                my $n_n = $xn_n * $yd_n - $yn_n * $xd_n;
+                my $sign = $n_n < 1 ? "-" : "+";
+                $n_n = abs($n_n);
+                my $d_n = $xd_n * $yd_n;
+
+                my $n = SYMBOL_NIL;
+                for (1..$n_n) {
+                    $n = make_pair(
+                        SYMBOL_T,
+                        $n,
+                    );
+                }
+
+                my $d = SYMBOL_NIL;
+                for (1..$d_n) {
+                    $d = make_pair(
+                        SYMBOL_T,
+                        $d,
+                    );
+                }
+
+                $real_part = make_pair(
+                    make_symbol($sign),
+                    make_pair(
+                        $n,
+                        make_pair(
+                            $d,
+                            SYMBOL_NIL,
+                        ),
+                    ),
+                );
+            }
+            else {
+                my $xn_n = 0;
+                while (!is_nil($xn)) {
+                    ++$xn_n;
+                    $xn = $bel->cdr($xn);
+                }
+
+                my $xd_n = 0;
+                while (!is_nil($xd)) {
+                    ++$xd_n;
+                    $xd = $bel->cdr($xd);
+                }
+
+                my $yn_n = 0;
+                while (!is_nil($yn)) {
+                    ++$yn_n;
+                    $yn = $bel->cdr($yn);
+                }
+
+                my $yd_n = 0;
+                while (!is_nil($yd)) {
+                    ++$yd_n;
+                    $yd = $bel->cdr($yd);
+                }
+
+                my $n_n = $xn_n * $yd_n + $yn_n * $xd_n;
+                my $d_n = $xd_n * $yd_n;
+
+                my $n = SYMBOL_NIL;
+                for (1..$n_n) {
+                    $n = make_pair(
+                        SYMBOL_T,
+                        $n,
+                    );
+                }
+
+                my $d = SYMBOL_NIL;
+                for (1..$d_n) {
+                    $d = make_pair(
+                        SYMBOL_T,
+                        $d,
+                    );
+                }
+
+                $real_part = make_pair(
+                    make_symbol("+"),
+                    make_pair(
+                        $n,
+                        make_pair(
+                            $d,
+                            SYMBOL_NIL,
+                        ),
+                    ),
+                );
+            }
+        }
+    }
+
+    my $imaginary_part;
+    {
+        my $xs = $bel->car($xi);
+        my $xn = $bel->car($bel->cdr($xi));
+        my $xd = $bel->car($bel->cdr($bel->cdr($xi)));
+
+        my $ys = $bel->car($yi);
+        my $yn = $bel->car($bel->cdr($yi));
+        my $yd = $bel->car($bel->cdr($bel->cdr($yi)));
+
+        my $symbol;
+        if (is_symbol_of_name($xs, "-")) {
+            if (is_symbol_of_name($ys, "-")) {
+                my $xn_n = 0;
+                while (!is_nil($xn)) {
+                    ++$xn_n;
+                    $xn = $bel->cdr($xn);
+                }
+
+                my $xd_n = 0;
+                while (!is_nil($xd)) {
+                    ++$xd_n;
+                    $xd = $bel->cdr($xd);
+                }
+
+                my $yn_n = 0;
+                while (!is_nil($yn)) {
+                    ++$yn_n;
+                    $yn = $bel->cdr($yn);
+                }
+
+                my $yd_n = 0;
+                while (!is_nil($yd)) {
+                    ++$yd_n;
+                    $yd = $bel->cdr($yd);
+                }
+
+                my $n_n = $xn_n * $yd_n + $yn_n * $xd_n;
+                my $d_n = $xd_n * $yd_n;
+
+                my $n = SYMBOL_NIL;
+                for (1..$n_n) {
+                    $n = make_pair(
+                        SYMBOL_T,
+                        $n,
+                    );
+                }
+
+                my $d = SYMBOL_NIL;
+                for (1..$d_n) {
+                    $d = make_pair(
+                        SYMBOL_T,
+                        $d,
+                    );
+                }
+
+                $imaginary_part = make_pair(
+                    make_symbol("-"),
+                    make_pair(
+                        $n,
+                        make_pair(
+                            $d,
+                            SYMBOL_NIL,
+                        ),
+                    ),
+                );
+            }
+            else {
+                my $xn_n = 0;
+                while (!is_nil($xn)) {
+                    ++$xn_n;
+                    $xn = $bel->cdr($xn);
+                }
+
+                my $xd_n = 0;
+                while (!is_nil($xd)) {
+                    ++$xd_n;
+                    $xd = $bel->cdr($xd);
+                }
+
+                my $yn_n = 0;
+                while (!is_nil($yn)) {
+                    ++$yn_n;
+                    $yn = $bel->cdr($yn);
+                }
+
+                my $yd_n = 0;
+                while (!is_nil($yd)) {
+                    ++$yd_n;
+                    $yd = $bel->cdr($yd);
+                }
+
+                my $n_n = $yn_n * $xd_n - $xn_n * $yd_n;
+                my $sign = $n_n < 1 ? "-" : "+";
+                $n_n = abs($n_n);
+                my $d_n = $yd_n * $xd_n;
+
+                my $n = SYMBOL_NIL;
+                for (1..$n_n) {
+                    $n = make_pair(
+                        SYMBOL_T,
+                        $n,
+                    );
+                }
+
+                my $d = SYMBOL_NIL;
+                for (1..$d_n) {
+                    $d = make_pair(
+                        SYMBOL_T,
+                        $d,
+                    );
+                }
+
+                $imaginary_part = make_pair(
+                    make_symbol($sign),
+                    make_pair(
+                        $n,
+                        make_pair(
+                            $d,
+                            SYMBOL_NIL,
+                        ),
+                    ),
+                );
+            }
+        }
+        else {
+            if (is_symbol_of_name($ys, "-")) {
+                my $xn_n = 0;
+                while (!is_nil($xn)) {
+                    ++$xn_n;
+                    $xn = $bel->cdr($xn);
+                }
+
+                my $xd_n = 0;
+                while (!is_nil($xd)) {
+                    ++$xd_n;
+                    $xd = $bel->cdr($xd);
+                }
+
+                my $yn_n = 0;
+                while (!is_nil($yn)) {
+                    ++$yn_n;
+                    $yn = $bel->cdr($yn);
+                }
+
+                my $yd_n = 0;
+                while (!is_nil($yd)) {
+                    ++$yd_n;
+                    $yd = $bel->cdr($yd);
+                }
+
+                my $n_n = $xn_n * $yd_n - $yn_n * $xd_n;
+                my $sign = $n_n < 1 ? "-" : "+";
+                $n_n = abs($n_n);
+                my $d_n = $xd_n * $yd_n;
+
+                my $n = SYMBOL_NIL;
+                for (1..$n_n) {
+                    $n = make_pair(
+                        SYMBOL_T,
+                        $n,
+                    );
+                }
+
+                my $d = SYMBOL_NIL;
+                for (1..$d_n) {
+                    $d = make_pair(
+                        SYMBOL_T,
+                        $d,
+                    );
+                }
+
+                $imaginary_part = make_pair(
+                    make_symbol($sign),
+                    make_pair(
+                        $n,
+                        make_pair(
+                            $d,
+                            SYMBOL_NIL,
+                        ),
+                    ),
+                );
+            }
+            else {
+                my $xn_n = 0;
+                while (!is_nil($xn)) {
+                    ++$xn_n;
+                    $xn = $bel->cdr($xn);
+                }
+
+                my $xd_n = 0;
+                while (!is_nil($xd)) {
+                    ++$xd_n;
+                    $xd = $bel->cdr($xd);
+                }
+
+                my $yn_n = 0;
+                while (!is_nil($yn)) {
+                    ++$yn_n;
+                    $yn = $bel->cdr($yn);
+                }
+
+                my $yd_n = 0;
+                while (!is_nil($yd)) {
+                    ++$yd_n;
+                    $yd = $bel->cdr($yd);
+                }
+
+                my $n_n = $xn_n * $yd_n + $yn_n * $xd_n;
+                my $d_n = $xd_n * $yd_n;
+
+                my $n = SYMBOL_NIL;
+                for (1..$n_n) {
+                    $n = make_pair(
+                        SYMBOL_T,
+                        $n,
+                    );
+                }
+
+                my $d = SYMBOL_NIL;
+                for (1..$d_n) {
+                    $d = make_pair(
+                        SYMBOL_T,
+                        $d,
+                    );
+                }
+
+                $imaginary_part = make_pair(
+                    make_symbol("+"),
+                    make_pair(
+                        $n,
+                        make_pair(
+                            $d,
+                            SYMBOL_NIL,
+                        ),
+                    ),
+                );
+            }
+        }
+    }
+
+    return make_pair(
+        $real_part,
+        make_pair(
+            $imaginary_part,
+            SYMBOL_NIL,
+        ),
+    );
+}
+
+sub fastfunc__c_star {
+    my ($bel, $x, $y) = @_;
+    
+    my $xr = $bel->car($x);
+    my $xi = $bel->car($bel->cdr($x));
+    
+    my $yr = $bel->car($y);
+    my $yi = $bel->car($bel->cdr($y));
+    
+    my $real_part;
+    {
+        my $term1s;
+        my $term1n_n;
+        my $term1d_n;
+        
+        {
+            my $xs = $bel->car($xr);
+            my $xn = $bel->car($bel->cdr($xr));
+            my $xd = $bel->car($bel->cdr($bel->cdr($xr)));
+        
+            my $ys = $bel->car($yr);
+            my $yn = $bel->car($bel->cdr($yr));
+            my $yd = $bel->car($bel->cdr($bel->cdr($yr)));
+        
+            $term1s = is_symbol_of_name($xs, "-")
+                ? make_symbol(is_symbol_of_name($ys, "-") ? "+" : "-")
+                : $ys;
+        
+            my $xn_n = 0;
+            while (!is_nil($xn)) {
+                ++$xn_n;
+                $xn = $bel->cdr($xn);
+            }
+        
+            my $xd_n = 0;
+            while (!is_nil($xd)) {
+                ++$xd_n;
+                $xd = $bel->cdr($xd);
+            }
+        
+            my $yn_n = 0;
+            while (!is_nil($yn)) {
+                ++$yn_n;
+                $yn = $bel->cdr($yn);
+            }
+        
+            my $yd_n = 0;
+            while (!is_nil($yd)) {
+                ++$yd_n;
+                $yd = $bel->cdr($yd);
+            }
+        
+            $term1n_n = $xn_n * $yn_n;
+            $term1d_n = $xd_n * $yd_n;
+        }
+    
+        my $term2s;
+        my $term2n_n;
+        my $term2d_n;
+        
+        {
+            my $xs = $bel->car($xi);
+            my $xn = $bel->car($bel->cdr($xi));
+            my $xd = $bel->car($bel->cdr($bel->cdr($xi)));
+        
+            my $ys = $bel->car($yi);
+            my $yn = $bel->car($bel->cdr($yi));
+            my $yd = $bel->car($bel->cdr($bel->cdr($yi)));
+        
+            $term2s = is_symbol_of_name($xs, "-")
+                ? make_symbol(is_symbol_of_name($ys, "-") ? "+" : "-")
+                : $ys;
+        
+            my $xn_n = 0;
+            while (!is_nil($xn)) {
+                ++$xn_n;
+                $xn = $bel->cdr($xn);
+            }
+        
+            my $xd_n = 0;
+            while (!is_nil($xd)) {
+                ++$xd_n;
+                $xd = $bel->cdr($xd);
+            }
+        
+            my $yn_n = 0;
+            while (!is_nil($yn)) {
+                ++$yn_n;
+                $yn = $bel->cdr($yn);
+            }
+        
+            my $yd_n = 0;
+            while (!is_nil($yd)) {
+                ++$yd_n;
+                $yd = $bel->cdr($yd);
+            }
+        
+            $term2n_n = $xn_n * $yn_n;
+            $term2d_n = $xd_n * $yd_n;
+        }
+    
+        if (is_symbol_of_name($term1s, "-")) {
+            if (is_symbol_of_name($term2s, "-")) {
+                my $n_n = $term2n_n * $term1d_n - $term1n_n * $term2d_n;
+                my $sign = $n_n < 1 ? "-" : "+";
+                $n_n = abs($n_n);
+                my $d_n = $term2d_n * $term1d_n;
+    
+                my $n = SYMBOL_NIL;
+                for (1..$n_n) {
+                    $n = make_pair(
+                        SYMBOL_T,
+                        $n,
+                    );
+                }
+    
+                my $d = SYMBOL_NIL;
+                for (1..$d_n) {
+                    $d = make_pair(
+                        SYMBOL_T,
+                        $d,
+                    );
+                }
+    
+                $real_part = make_pair(
+                    make_symbol($sign),
+                    make_pair(
+                        $n,
+                        make_pair(
+                            $d,
+                            SYMBOL_NIL,
+                        ),
+                    ),
+                );
+            }
+            else {
+                my $n_n = $term1n_n * $term2d_n + $term2n_n * $term1d_n;
+                my $d_n = $term1d_n * $term2d_n;
+    
+                my $n = SYMBOL_NIL;
+                for (1..$n_n) {
+                    $n = make_pair(
+                        SYMBOL_T,
+                        $n,
+                    );
+                }
+    
+                my $d = SYMBOL_NIL;
+                for (1..$d_n) {
+                    $d = make_pair(
+                        SYMBOL_T,
+                        $d,
+                    );
+                }
+    
+                $real_part = make_pair(
+                    make_symbol("-"),
+                    make_pair(
+                        $n,
+                        make_pair(
+                            $d,
+                            SYMBOL_NIL,
+                        ),
+                    ),
+                );
+            }
+        }
+        else {
+            if (is_symbol_of_name($term2s, "-")) {
+                my $n_n = $term1n_n * $term2d_n + $term2n_n * $term1d_n;
+                my $d_n = $term1d_n * $term2d_n;
+    
+                my $n = SYMBOL_NIL;
+                for (1..$n_n) {
+                    $n = make_pair(
+                        SYMBOL_T,
+                        $n,
+                    );
+                }
+    
+                my $d = SYMBOL_NIL;
+                for (1..$d_n) {
+                    $d = make_pair(
+                        SYMBOL_T,
+                        $d,
+                    );
+                }
+    
+                $real_part = make_pair(
+                    make_symbol("+"),
+                    make_pair(
+                        $n,
+                        make_pair(
+                            $d,
+                            SYMBOL_NIL,
+                        ),
+                    ),
+                );
+            }
+            else {
+                my $n_n = $term1n_n * $term2d_n - $term2n_n * $term1d_n;
+                my $sign = $n_n < 1 && $term2n_n > 0 ? "-" : "+";
+                $n_n = abs($n_n);
+                my $d_n = $term1d_n * $term2d_n;
+    
+                my $n = SYMBOL_NIL;
+                for (1..$n_n) {
+                    $n = make_pair(
+                        SYMBOL_T,
+                        $n,
+                    );
+                }
+    
+                my $d = SYMBOL_NIL;
+                for (1..$d_n) {
+                    $d = make_pair(
+                        SYMBOL_T,
+                        $d,
+                    );
+                }
+    
+                $real_part = make_pair(
+                    make_symbol($sign),
+                    make_pair(
+                        $n,
+                        make_pair(
+                            $d,
+                            SYMBOL_NIL,
+                        ),
+                    ),
+                );
+            }
+        }
+    }
+    
+    my $imaginary_part;
+    {
+        my $term1s;
+        my $term1n_n;
+        my $term1d_n;
+        
+        {
+            my $xs = $bel->car($xi);
+            my $xn = $bel->car($bel->cdr($xi));
+            my $xd = $bel->car($bel->cdr($bel->cdr($xi)));
+        
+            my $ys = $bel->car($yr);
+            my $yn = $bel->car($bel->cdr($yr));
+            my $yd = $bel->car($bel->cdr($bel->cdr($yr)));
+        
+            $term1s = is_symbol_of_name($xs, "-")
+                ? make_symbol(is_symbol_of_name($ys, "-") ? "+" : "-")
+                : $ys;
+        
+            my $xn_n = 0;
+            while (!is_nil($xn)) {
+                ++$xn_n;
+                $xn = $bel->cdr($xn);
+            }
+        
+            my $xd_n = 0;
+            while (!is_nil($xd)) {
+                ++$xd_n;
+                $xd = $bel->cdr($xd);
+            }
+        
+            my $yn_n = 0;
+            while (!is_nil($yn)) {
+                ++$yn_n;
+                $yn = $bel->cdr($yn);
+            }
+        
+            my $yd_n = 0;
+            while (!is_nil($yd)) {
+                ++$yd_n;
+                $yd = $bel->cdr($yd);
+            }
+        
+            $term1n_n = $xn_n * $yn_n;
+            $term1d_n = $xd_n * $yd_n;
+        }
+    
+        my $term2s;
+        my $term2n_n;
+        my $term2d_n;
+        
+        {
+            my $xs = $bel->car($xr);
+            my $xn = $bel->car($bel->cdr($xr));
+            my $xd = $bel->car($bel->cdr($bel->cdr($xr)));
+        
+            my $ys = $bel->car($yi);
+            my $yn = $bel->car($bel->cdr($yi));
+            my $yd = $bel->car($bel->cdr($bel->cdr($yi)));
+        
+            $term2s = is_symbol_of_name($xs, "-")
+                ? make_symbol(is_symbol_of_name($ys, "-") ? "+" : "-")
+                : $ys;
+        
+            my $xn_n = 0;
+            while (!is_nil($xn)) {
+                ++$xn_n;
+                $xn = $bel->cdr($xn);
+            }
+        
+            my $xd_n = 0;
+            while (!is_nil($xd)) {
+                ++$xd_n;
+                $xd = $bel->cdr($xd);
+            }
+        
+            my $yn_n = 0;
+            while (!is_nil($yn)) {
+                ++$yn_n;
+                $yn = $bel->cdr($yn);
+            }
+        
+            my $yd_n = 0;
+            while (!is_nil($yd)) {
+                ++$yd_n;
+                $yd = $bel->cdr($yd);
+            }
+        
+            $term2n_n = $xn_n * $yn_n;
+            $term2d_n = $xd_n * $yd_n;
+        }
+    
+        if (is_symbol_of_name($term1s, "-")) {
+            if (is_symbol_of_name($term2s, "-")) {
+                my $n_n = $term1n_n * $term2d_n + $term2n_n * $term1d_n;
+                my $d_n = $term1d_n * $term2d_n;
+    
+                my $n = SYMBOL_NIL;
+                for (1..$n_n) {
+                    $n = make_pair(
+                        SYMBOL_T,
+                        $n,
+                    );
+                }
+    
+                my $d = SYMBOL_NIL;
+                for (1..$d_n) {
+                    $d = make_pair(
+                        SYMBOL_T,
+                        $d,
+                    );
+                }
+    
+                $imaginary_part = make_pair(
+                    make_symbol("-"),
+                    make_pair(
+                        $n,
+                        make_pair(
+                            $d,
+                            SYMBOL_NIL,
+                        ),
+                    ),
+                );
+            }
+            else {
+                my $n_n = $term2n_n * $term1d_n - $term1n_n * $term2d_n;
+                my $sign = $n_n < 1 ? "-" : "+";
+                $n_n = abs($n_n);
+                my $d_n = $term2d_n * $term1d_n;
+    
+                my $n = SYMBOL_NIL;
+                for (1..$n_n) {
+                    $n = make_pair(
+                        SYMBOL_T,
+                        $n,
+                    );
+                }
+    
+                my $d = SYMBOL_NIL;
+                for (1..$d_n) {
+                    $d = make_pair(
+                        SYMBOL_T,
+                        $d,
+                    );
+                }
+    
+                $imaginary_part = make_pair(
+                    make_symbol($sign),
+                    make_pair(
+                        $n,
+                        make_pair(
+                            $d,
+                            SYMBOL_NIL,
+                        ),
+                    ),
+                );
+            }
+        }
+        else {
+            if (is_symbol_of_name($term2s, "-")) {
+                my $n_n = $term1n_n * $term2d_n - $term2n_n * $term1d_n;
+                my $sign = $n_n < 1 ? "-" : "+";
+                $n_n = abs($n_n);
+                my $d_n = $term1d_n * $term2d_n;
+    
+                my $n = SYMBOL_NIL;
+                for (1..$n_n) {
+                    $n = make_pair(
+                        SYMBOL_T,
+                        $n,
+                    );
+                }
+    
+                my $d = SYMBOL_NIL;
+                for (1..$d_n) {
+                    $d = make_pair(
+                        SYMBOL_T,
+                        $d,
+                    );
+                }
+    
+                $imaginary_part = make_pair(
+                    make_symbol($sign),
+                    make_pair(
+                        $n,
+                        make_pair(
+                            $d,
+                            SYMBOL_NIL,
+                        ),
+                    ),
+                );
+            }
+            else {
+                my $n_n = $term1n_n * $term2d_n + $term2n_n * $term1d_n;
+                my $d_n = $term1d_n * $term2d_n;
+    
+                my $n = SYMBOL_NIL;
+                for (1..$n_n) {
+                    $n = make_pair(
+                        SYMBOL_T,
+                        $n,
+                    );
+                }
+    
+                my $d = SYMBOL_NIL;
+                for (1..$d_n) {
+                    $d = make_pair(
+                        SYMBOL_T,
+                        $d,
+                    );
+                }
+    
+                $imaginary_part = make_pair(
+                    make_symbol("+"),
+                    make_pair(
+                        $n,
+                        make_pair(
+                            $d,
+                            SYMBOL_NIL,
+                        ),
+                    ),
+                );
+            }
+        }
+    }
+    
+    return make_pair(
+        $real_part,
+        make_pair(
+            $imaginary_part,
+            SYMBOL_NIL,
+        ),
+    );
+}
+
+sub fastfunc__litnum {
+    my ($bel, $r, $i) = @_;
+
+    if (!defined($i)) {
+        $i = make_pair(
+            make_symbol("+"),
+            make_pair(
+                SYMBOL_NIL,
+                make_pair(
+                    make_pair(
+                        SYMBOL_T,
+                        SYMBOL_NIL,
+                    ),
+                    SYMBOL_NIL,
+                ),
+            ),
+        );
+    }
+
+    return make_pair(
+        make_symbol("lit"),
+        make_pair(
+            make_symbol("num"),
+            make_pair(
+                $r,
+                make_pair(
+                    $i,
+                    SYMBOL_NIL,
+                ),
+            ),
+        ),
+    );
+}
+
+sub fastfunc__number {
+    my ($bel, $x) = @_;
+
+    if (!is_pair($x)) {
+        return SYMBOL_NIL;
+    }
+
+    if (!is_symbol_of_name($bel->car($x), "lit")) {
+        return SYMBOL_NIL;
+    }
+
+    $x = $bel->cdr($x);
+    if (!is_pair($x)) {
+        return SYMBOL_NIL;
+    }
+
+    if (!is_symbol_of_name($bel->car($x), "num")) {
+        return SYMBOL_NIL;
+    }
+
+    $x = $bel->cdr($x);
+    if (!is_pair($x)) {
+        return SYMBOL_NIL;
+    }
+
+    {
+        my $y = $bel->car($x);
+        if (!is_pair($y)) {
+            return SYMBOL_NIL;
+        }
+
+
+        my $sign = $bel->car($y);
+        if (!(is_symbol_of_name($sign, "+") || is_symbol_of_name($sign, "-"))) {
+            return SYMBOL_NIL;
+        }
+
+        $y = $bel->cdr($y);
+        if (!is_pair($y)) {
+            return SYMBOL_NIL;
+        }
+
+        {
+            my $z = $bel->car($y);
+            while (!is_nil($z)) {
+                if (!is_pair($z)) {
+                    return SYMBOL_NIL;
+                }
+                $z = $bel->cdr($z);
+            }
+        }
+
+        $y = $bel->cdr($y);
+        if (!is_pair($y)) {
+            return SYMBOL_NIL;
+        }
+
+        {
+            my $z = $bel->car($y);
+            while (!is_nil($z)) {
+                if (!is_pair($z)) {
+                    return SYMBOL_NIL;
+                }
+                $z = $bel->cdr($z);
+            }
+        }
+    }
+
+    $x = $bel->cdr($x);
+    if (!is_pair($x)) {
+        return SYMBOL_NIL;
+    }
+
+    {
+        my $y = $bel->car($x);
+        if (!is_pair($y)) {
+            return SYMBOL_NIL;
+        }
+
+
+        my $sign = $bel->car($y);
+        if (!(is_symbol_of_name($sign, "+") || is_symbol_of_name($sign, "-"))) {
+            return SYMBOL_NIL;
+        }
+
+        $y = $bel->cdr($y);
+        if (!is_pair($y)) {
+            return SYMBOL_NIL;
+        }
+
+        {
+            my $z = $bel->car($y);
+            while (!is_nil($z)) {
+                if (!is_pair($z)) {
+                    return SYMBOL_NIL;
+                }
+                $z = $bel->cdr($z);
+            }
+        }
+
+        $y = $bel->cdr($y);
+        if (!is_pair($y)) {
+            return SYMBOL_NIL;
+        }
+
+        {
+            my $z = $bel->car($y);
+            while (!is_nil($z)) {
+                if (!is_pair($z)) {
+                    return SYMBOL_NIL;
+                }
+                $z = $bel->cdr($z);
+            }
+        }
+    }
+
+    return SYMBOL_T;
+}
+
+sub fastfunc__numr {
+    my ($bel, $x) = @_;
+
+    return $bel->car($bel->cdr($bel->cdr($x)));
+}
+
+sub fastfunc__numi {
+    my ($bel, $x) = @_;
+
+    return $bel->car($bel->cdr($bel->cdr($bel->cdr($x))));
+}
+
+sub fastfunc__rpart {
+    my ($bel, $n) = @_;
+
+    my $numr = $bel->car($bel->cdr($bel->cdr($n)));
+
+    my $i = make_pair(
+        make_symbol("+"),
+        make_pair(
+            SYMBOL_NIL,
+            make_pair(
+                make_pair(
+                    SYMBOL_T,
+                    SYMBOL_NIL,
+                ),
+                SYMBOL_NIL,
+            ),
+        ),
+    );
+
+    return make_pair(
+        make_symbol("lit"),
+        make_pair(
+            make_symbol("num"),
+            make_pair(
+                $numr,
+                make_pair(
+                    $i,
+                    SYMBOL_NIL,
+                ),
+            ),
+        ),
+    );
+}
+
+sub fastfunc__ipart {
+    my ($bel, $n) = @_;
+
+    my $numi = $bel->car($bel->cdr($bel->cdr($bel->cdr($n))));
+
+    my $i = make_pair(
+        make_symbol("+"),
+        make_pair(
+            SYMBOL_NIL,
+            make_pair(
+                make_pair(
+                    SYMBOL_T,
+                    SYMBOL_NIL,
+                ),
+                SYMBOL_NIL,
+            ),
+        ),
+    );
+
+    return make_pair(
+        make_symbol("lit"),
+        make_pair(
+            make_symbol("num"),
+            make_pair(
+                $numi,
+                make_pair(
+                    $i,
+                    SYMBOL_NIL,
+                ),
+            ),
+        ),
+    );
+}
+
+sub fastfunc__real {
+    my ($bel, $x) = @_;
+
+    if (!is_pair($x)) {
+        return SYMBOL_NIL;
+    }
+
+    if (!is_symbol_of_name($bel->car($x), "lit")) {
+        return SYMBOL_NIL;
+    }
+
+    $x = $bel->cdr($x);
+    if (!is_pair($x)) {
+        return SYMBOL_NIL;
+    }
+
+    if (!is_symbol_of_name($bel->car($x), "num")) {
+        return SYMBOL_NIL;
+    }
+
+    $x = $bel->cdr($x);
+    if (!is_pair($x)) {
+        return SYMBOL_NIL;
+    }
+
+    {
+        my $y = $bel->car($x);
+        if (!is_pair($y)) {
+            return SYMBOL_NIL;
+        }
+
+
+        my $sign = $bel->car($y);
+        if (!(is_symbol_of_name($sign, "+") || is_symbol_of_name($sign, "-"))) {
+            return SYMBOL_NIL;
+        }
+
+        $y = $bel->cdr($y);
+        if (!is_pair($y)) {
+            return SYMBOL_NIL;
+        }
+
+        {
+            my $z = $bel->car($y);
+            while (!is_nil($z)) {
+                if (!is_pair($z)) {
+                    return SYMBOL_NIL;
+                }
+                $z = $bel->cdr($z);
+            }
+        }
+
+        $y = $bel->cdr($y);
+        if (!is_pair($y)) {
+            return SYMBOL_NIL;
+        }
+
+        {
+            my $z = $bel->car($y);
+            while (!is_nil($z)) {
+                if (!is_pair($z)) {
+                    return SYMBOL_NIL;
+                }
+                $z = $bel->cdr($z);
+            }
+        }
+    }
+
+    $x = $bel->cdr($x);
+    if (!is_pair($x)) {
+        return SYMBOL_NIL;
+    }
+
+    {
+        my $y = $bel->car($x);
+        if (!is_pair($y)) {
+            return SYMBOL_NIL;
+        }
+
+
+        my $sign = $bel->car($y);
+        if (!is_symbol_of_name($sign, "+")) {
+            return SYMBOL_NIL;
+        }
+
+        $y = $bel->cdr($y);
+        if (!is_pair($y)) {
+            return SYMBOL_NIL;
+        }
+
+        if (!is_nil($bel->car($y))) {
+            return SYMBOL_NIL;
+        }
+
+        $y = $bel->cdr($y);
+        if (!is_pair($y)) {
+            return SYMBOL_NIL;
+        }
+
+        {
+            my $z = $bel->car($y);
+            my $t = 0;
+            while (!is_nil($z)) {
+                if (!is_pair($z)) {
+                    return SYMBOL_NIL;
+                }
+                $z = $bel->cdr($z);
+                $t++;
+            }
+
+            if ($t != 1) {
+                return SYMBOL_NIL;
+            }
+        }
+    }
+
+    return SYMBOL_T;
+}
+
+sub fastfunc__prn {
+    my ($bel, @args) = @_;
+
+    my $last = SYMBOL_NIL;
+    for (@args) {
+        $bel->output(Language::Bel::Printer::_print($_));
+        $bel->output(" ");
+        $last = $_;
+    }
+    $bel->output("\n");
+    return $last;
+}
+
+sub fastfunc__pr {
+    my ($bel, @args) = @_;
+
+    $bel->output($_) for
+        map { Language::Bel::Printer::prnice($_) }
+        @args;
+
+    my $result = SYMBOL_NIL;
+    while (@args) {
+        $result = make_pair(pop(@args), $result);
+    }
+    return $result;
+}
+
+sub fastfunc__prs {
+    my ($bel, @args) = @_;
+
+    my @strings;
+    for (@args) {
+        push(@strings, Language::Bel::Printer::prnice($_));
+    }
+
+    my $result = SYMBOL_NIL;
+    while (@strings) {
+        my $string = pop(@strings);
+        for my $char (reverse(split //, $string)) {
+            my $c = make_char(ord($char));
+            $result = make_pair($c, $result);
+        }
+    }
+    return $result;
+}
+
+our @EXPORT_OK = qw(
+    fastfunc__no
+    fastfunc__atom
+    fastfunc__all
+    fastfunc__some
+    fastfunc__where__some
+    fastfunc__reduce
+    fastfunc__cons
+    fastfunc__append
+    fastfunc__snoc
+    fastfunc__list
+    fastfunc__map
+    fastfunc__eq
+    fastfunc__symbol
+    fastfunc__pair
+    fastfunc__char
+    fastfunc__proper
+    fastfunc__string
+    fastfunc__mem
+    fastfunc__where__mem
+    fastfunc__in
+    fastfunc__where__in
+    fastfunc__cadr
+    fastfunc__where__cadr
+    fastfunc__cddr
+    fastfunc__where__cddr
+    fastfunc__caddr
+    fastfunc__where__caddr
+    fastfunc__find
+    fastfunc__where__find
+    fastfunc__begins
+    fastfunc__caris
+    fastfunc__hug
+    fastfunc__keep
+    fastfunc__rem
+    fastfunc__get
+    fastfunc__where__get
+    fastfunc__put
+    fastfunc__rev
+    fastfunc__snap
+    fastfunc__udrop
+    fastfunc__idfn
+    fastfunc__where__idfn
+    fastfunc__pairwise
+    fastfunc__foldl
+    fastfunc__foldr
+    fastfunc__fuse
+    fastfunc__match
+    fastfunc__split
+    fastfunc__i_lt
+    fastfunc__i_plus
+    fastfunc__i_minus
+    fastfunc__i_star
+    fastfunc__i_slash
+    fastfunc__i_hat
+    fastfunc__r_plus
+    fastfunc__r_minus
+    fastfunc__r_star
+    fastfunc__r_slash
+    fastfunc__sr_plus
+    fastfunc__sr_minus
+    fastfunc__srinv
+    fastfunc__sr_star
+    fastfunc__sr_slash
+    fastfunc__srrecip
+    fastfunc__sr_lt
+    fastfunc__srnum
+    fastfunc__where__srnum
+    fastfunc__srden
+    fastfunc__where__srden
+    fastfunc__c_plus
+    fastfunc__c_star
+    fastfunc__litnum
+    fastfunc__number
+    fastfunc__numr
+    fastfunc__numi
+    fastfunc__rpart
+    fastfunc__ipart
+    fastfunc__real
+    fastfunc__prn
+    fastfunc__pr
+    fastfunc__prs
+);
+
+1;

--- a/lib/Language/Bel/Globals/FastFuncs/Visitor.pm
+++ b/lib/Language/Bel/Globals/FastFuncs/Visitor.pm
@@ -1,0 +1,401 @@
+package Language::Bel::Globals::FastFuncs::Visitor;
+
+use 5.006;
+use strict;
+use warnings;
+
+use Exporter 'import';
+
+sub visit {
+    my ($node, $ancestors_ref, $rules_ref) = @_;
+
+    if (!defined($ancestors_ref)) {
+        $ancestors_ref = [];
+    }
+    if (!defined($rules_ref)) {
+        $rules_ref = {};
+    }
+
+    # Perform a postorder traversal of the AST.
+
+    my $type = $node->{type};
+
+    if ($type eq "expr_statement"
+        && $node->{children}[0]{type} eq "call"
+        && $node->{children}[0]{children}[0]{type} eq "bareword") {
+        my $name = $node->{children}[0]{children}[0]{name};
+        if ($name eq "ITERATE_FORWARD") {
+            my ($elem_var, $list_var, $sub)
+                = @{ $node->{children}[0]{children}[1]{children} };
+
+            # $xs = $bel->cdr($xs);
+            # {{{variable}}} = $bel->cdr({{{variable}}};
+            #    $list_var                  $list_var
+            my $statement_list = {
+                type => "statement_list",
+                children => [
+                    @{ $sub->{children}[0]{children} },
+                    {
+                        type => "expr_statement",
+                        children => [
+                            {
+                                type => "assign",
+                                children => [
+                                    $list_var,
+                                    {
+                                        type => "call",
+                                        children => [
+                                            {
+                                                # hack
+                                                type => "variable",
+                                                name => q[$bel->cdr],
+                                            },
+                                            {
+                                                type => "argument_list",
+                                                children => [
+                                                    $list_var,
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            %{ $node } = (
+                type => "while_statement",
+                children => [
+                    {
+                        type => "not",
+                        children => [
+                            {
+                                type => "call",
+                                children => [
+                                    {
+                                        type => "bareword",
+                                        name => "is_nil",
+                                    },
+                                    {
+                                        type => "argument_list",
+                                        children => [$list_var],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    $statement_list,
+                ],
+            );
+
+            if (scalar(@{ $ancestors_ref }) > 0) {
+                my $statement_list = $ancestors_ref->[-1];
+                my @statements = @{ $statement_list->{children} };
+                my $i = 0;
+
+                my $prev_sibling;
+                SIBLING:
+                for my $curr_sibling (@statements) {
+                    if ($curr_sibling == $node) {
+                        if (defined($prev_sibling)
+                            && $prev_sibling->{type} eq "my_statement"
+                            && $prev_sibling->{children}[0]{children}[0]{type}
+                                eq "variable"
+                            && $prev_sibling->{children}[0]{children}[0]{name}
+                                eq $elem_var->{name}) {
+                            splice(@{ $statement_list->{children} }, $i-1, 1);
+                        }
+
+                        last SIBLING;
+                    }
+
+                    $prev_sibling = $curr_sibling;
+                    $i++;
+                }
+            }
+
+            $rules_ref->{$node} = sub {
+                my ($descendant_node) = @_;
+
+                if ($descendant_node->{type} eq "variable"
+                    && $descendant_node->{name} eq $elem_var->{name}) {
+                    %{ $descendant_node } = (
+                        type => "call",
+                        children => [
+                            {
+                                type => "variable",
+                                name => q[$bel->car],
+                            },
+                            {
+                                type => "argument_list",
+                                children => [$list_var],
+                            },
+                        ],
+                    );
+                }
+            };
+        }
+        elsif ($name eq "ITERATE_FORWARD_OF") {
+            my ($elem_var, $pair_var, $list_var, $sub)
+                = @{ $node->{children}[0]{children}[1]{children} };
+
+            # $xs = $bel->cdr($xs);
+            # {{{variable}}} = $bel->cdr({{{variable}}};
+            #    $list_var                  $list_var
+            my $statement_list = {
+                type => "statement_list",
+                children => [
+                    @{ $sub->{children}[0]{children} },
+                    {
+                        type => "expr_statement",
+                        children => [
+                            {
+                                type => "assign",
+                                children => [
+                                    $list_var,
+                                    {
+                                        type => "call",
+                                        children => [
+                                            {
+                                                # hack
+                                                type => "variable",
+                                                name => q[$bel->cdr],
+                                            },
+                                            {
+                                                type => "argument_list",
+                                                children => [
+                                                    $list_var,
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            %{ $node } = (
+                type => "while_statement",
+                children => [
+                    {
+                        type => "not",
+                        children => [
+                            {
+                                type => "call",
+                                children => [
+                                    {
+                                        type => "bareword",
+                                        name => "is_nil",
+                                    },
+                                    {
+                                        type => "argument_list",
+                                        children => [$list_var],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    $statement_list,
+                ],
+            );
+
+            if (scalar(@{ $ancestors_ref }) > 0) {
+                my $statement_list = $ancestors_ref->[-1];
+                my @statements = @{ $statement_list->{children} };
+                my $i = 0;
+
+                my $prev_sibling;
+                SIBLING:
+                for my $curr_sibling (@statements) {
+                    if ($curr_sibling == $node) {
+                        if (defined($prev_sibling)
+                            && $prev_sibling->{type} eq "my_statement"
+                            && $prev_sibling->{children}[0]{children}[0]{type}
+                                eq "variable"
+                            && $prev_sibling->{children}[0]{children}[0]{name}
+                                eq $elem_var->{name}) {
+                            splice(@{ $statement_list->{children} }, $i-1, 1);
+                        }
+                        elsif (defined($prev_sibling)
+                            && $prev_sibling->{type} eq "my_statement"
+                            && $prev_sibling->{children}[0]{children}[0]{type}
+                                eq "variable_list"
+                            && 0 == grep {
+                                $_->{name} ne $elem_var->{name}
+                                && $_->{name} ne $pair_var->{name} }
+                                @{ $prev_sibling->{children}[0]{children}[0]{children} }) {
+                            splice(@{ $statement_list->{children} }, $i-1, 1);
+                        }
+
+                        last SIBLING;
+                    }
+
+                    $prev_sibling = $curr_sibling;
+                    $i++;
+                }
+            }
+
+            $rules_ref->{$node} = sub {
+                my ($descendant_node) = @_;
+
+                if ($descendant_node->{type} eq "variable"
+                    && $descendant_node->{name} eq $pair_var->{name}) {
+                    %{ $descendant_node } = (
+                        type => "variable",
+                        name => $list_var->{name},
+                    );
+                }
+                elsif ($descendant_node->{type} eq "variable"
+                    && $descendant_node->{name} eq $elem_var->{name}) {
+                    %{ $descendant_node } = (
+                        type => "call",
+                        children => [
+                            {
+                                type => "variable",
+                                name => q[$bel->car],
+                            },
+                            {
+                                type => "argument_list",
+                                children => [$list_var],
+                            },
+                        ],
+                    );
+                }
+            };
+        }
+        elsif ($name eq "IF") {
+            my ($condition, $sub)
+                = @{ $node->{children}[0]{children}[1]{children} };
+
+            %{ $node } = (
+                type => "if_statement",
+                children => [
+                    {
+                        type => "not",
+                        children => [
+                            {
+                                type => "call",
+                                children => [
+                                    {
+                                        type => "bareword",
+                                        name => "is_nil",
+                                    },
+                                    {
+                                        type => "argument_list",
+                                        children => [$condition],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    $sub->{children}[0],
+                ],
+            );
+        }
+        elsif ($name eq "UNLESS") {
+            my ($condition, $sub)
+                = @{ $node->{children}[0]{children}[1]{children} };
+
+            %{ $node } = (
+                type => "if_statement",
+                children => [
+                    {
+                        type => "call",
+                        children => [
+                            {
+                                type => "bareword",
+                                name => "is_nil",
+                            },
+                            {
+                                type => "argument_list",
+                                children => [$condition],
+                            },
+                        ],
+                    },
+                    $sub->{children}[0],
+                ],
+            );
+        }
+        else {
+            # we let it through on this level; catch any unknown macro
+            # calls on the next lower level
+        }
+    }
+    elsif ($type eq "call" && $node->{children}[0]{type} eq "bareword") {
+        my $name = $node->{children}[0]{name};
+        if ($name eq "CALL") {
+            my ($fn, @args) = @{ $node->{children}[1]{children} };
+
+            # $bel->call($f, $bel->car($xs))
+            # cheatish, hackish, I don't care
+            %{ $node } = (
+                type => "call",
+                children => [
+                    {
+                        type => "variable",
+                        name => q[$bel->call],
+                    },
+                    {
+                        type => "argument_list",
+                        children => [
+                            $fn,
+                            @args,
+                        ],
+                    },
+                ],
+            );
+        }
+        elsif ($name =~ /^[a-z_]+$/) {
+            # Not a macro call, so we just let it through
+        }
+        else {
+            die "Don't know how to handle macro call ", $name, "()";
+        }
+    }
+    elsif ($type eq "bareword") {
+        my $name = $node->{name};
+        if ($name eq "NIL") {
+            $node->{name} = "SYMBOL_NIL";
+        }
+        elsif ($name eq "T") {
+            $node->{name} = "SYMBOL_T";
+        }
+        elsif ($name =~ /^[a-z_]+$/) {
+            # Not a macro, so we just let it through
+        }
+        else {
+            die "Don't know how to handle bareword ", $name;
+        }
+    }
+    elsif ($type eq "variable") {
+    }
+
+    # apply the rules, innermost first
+    for my $ancestor (reverse(@{ $ancestors_ref })) {
+        if (exists $rules_ref->{$ancestor}) {
+            $rules_ref->{$ancestor}->($node);
+        }
+    }
+
+    my @children = exists $node->{children}
+        ? @{ $node->{children} }
+        : ();
+
+    push @{ $ancestors_ref }, $node;
+    for my $child (@children) {
+        $child = visit($child, $ancestors_ref, $rules_ref);
+    }
+    pop @{ $ancestors_ref };
+
+    return $node;
+}
+
+our @EXPORT_OK = qw(
+    visit
+);
+
+1;

--- a/lib/Language/Bel/Globals/FastFuncs/Visitor.pm
+++ b/lib/Language/Bel/Globals/FastFuncs/Visitor.pm
@@ -43,18 +43,19 @@ sub visit {
                                 children => [
                                     $list_var,
                                     {
-                                        type => "call",
+                                        type => "method_call",
                                         children => [
                                             {
-                                                # hack
                                                 type => "variable",
-                                                name => q[$bel->cdr],
+                                                name => q[$bel],
+                                            },
+                                            {
+                                                type => "bareword",
+                                                name => q[cdr],
                                             },
                                             {
                                                 type => "argument_list",
-                                                children => [
-                                                    $list_var,
-                                                ],
+                                                children => [$list_var],
                                             },
                                         ],
                                     },
@@ -122,11 +123,15 @@ sub visit {
                 if ($descendant_node->{type} eq "variable"
                     && $descendant_node->{name} eq $elem_var->{name}) {
                     %{ $descendant_node } = (
-                        type => "call",
+                        type => "method_call",
                         children => [
                             {
                                 type => "variable",
-                                name => q[$bel->car],
+                                name => q[$bel],
+                            },
+                            {
+                                type => "bareword",
+                                name => q[car],
                             },
                             {
                                 type => "argument_list",
@@ -156,18 +161,19 @@ sub visit {
                                 children => [
                                     $list_var,
                                     {
-                                        type => "call",
+                                        type => "method_call",
                                         children => [
                                             {
-                                                # hack
                                                 type => "variable",
-                                                name => q[$bel->cdr],
+                                                name => q[$bel],
+                                            },
+                                            {
+                                                type => "bareword",
+                                                name => q[cdr],
                                             },
                                             {
                                                 type => "argument_list",
-                                                children => [
-                                                    $list_var,
-                                                ],
+                                                children => [$list_var],
                                             },
                                         ],
                                     },
@@ -252,11 +258,15 @@ sub visit {
                 elsif ($descendant_node->{type} eq "variable"
                     && $descendant_node->{name} eq $elem_var->{name}) {
                     %{ $descendant_node } = (
-                        type => "call",
+                        type => "method_call",
                         children => [
                             {
                                 type => "variable",
-                                name => q[$bel->car],
+                                name => q[$bel],
+                            },
+                            {
+                                type => "variable",
+                                name => q[car],
                             },
                             {
                                 type => "argument_list",
@@ -331,13 +341,16 @@ sub visit {
             my ($fn, @args) = @{ $node->{children}[1]{children} };
 
             # $bel->call($f, $bel->car($xs))
-            # cheatish, hackish, I don't care
             %{ $node } = (
-                type => "call",
+                type => "method_call",
                 children => [
                     {
                         type => "variable",
-                        name => q[$bel->call],
+                        name => q[$bel],
+                    },
+                    {
+                        type => "bareword",
+                        name => q[call],
                     },
                     {
                         type => "argument_list",

--- a/t/fastfunc-macro-expander.t
+++ b/t/fastfunc-macro-expander.t
@@ -8,7 +8,7 @@ use Language::Bel::Globals::FastFuncs::Preprocessor qw(
     expand
 );
 
-plan tests => 5;
+plan tests => 6;
 
 my $INDENT = " " x 4;
 
@@ -28,6 +28,24 @@ my $INDENT = " " x 4;
     my $actual_output = expand($input);
 
     is $actual_output, $expected_output, "T expands to SYMBOL_T";
+}
+
+{
+    my $input = <<'EOF';
+    my ($bel, $f, $xs) = @_;
+
+    return $bel->call($f, $xs);
+EOF
+
+    my $expected_output = <<'EOF';
+    my ($bel, $f, $xs) = @_;
+
+    return $bel->call($f, $xs);
+EOF
+
+    my $actual_output = expand($input);
+
+    is $actual_output, $expected_output, "can parse/emit method calls";
 }
 
 {

--- a/t/fastfunc-macro-expander.t
+++ b/t/fastfunc-macro-expander.t
@@ -1,0 +1,114 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings;
+use Test::More;
+
+use Language::Bel::Globals::FastFuncs::Preprocessor qw(
+    expand
+);
+
+plan tests => 5;
+
+my $INDENT = " " x 4;
+
+{
+    my $input = $INDENT . "return NIL;\n";
+    my $expected_output = $INDENT . "return SYMBOL_NIL;\n";
+
+    my $actual_output = expand($input);
+
+    is $actual_output, $expected_output, "NIL expands to SYMBOL_NIL";
+}
+
+{
+    my $input = $INDENT . "return T;\n";
+    my $expected_output = $INDENT . "return SYMBOL_T;\n";
+
+    my $actual_output = expand($input);
+
+    is $actual_output, $expected_output, "T expands to SYMBOL_T";
+}
+
+{
+    my $input = <<'EOF';
+    my ($bel, $x) = @_;
+
+    return is_nil($x) ? T : NIL;
+EOF
+
+    my $expected_output = <<'EOF';
+    my ($bel, $x) = @_;
+
+    return is_nil($x) ? SYMBOL_T : SYMBOL_NIL;
+EOF
+
+    my $actual_output = expand($input);
+
+    is $actual_output, $expected_output, "expansion of fastfunc__no";
+}
+
+{
+    my $input = <<'EOF';
+    my ($bel, $f, $xs) = @_;
+
+    my $x;
+    ITERATE_FORWARD($x, $xs, sub {
+        UNLESS(CALL($f, $x), sub {
+            return NIL;
+        });
+    });
+
+    return T;
+EOF
+
+    my $expected_output = <<'EOF';
+    my ($bel, $f, $xs) = @_;
+
+    while (!is_nil($xs)) {
+        if (is_nil($bel->call($f, $bel->car($xs)))) {
+            return SYMBOL_NIL;
+        }
+        $xs = $bel->cdr($xs);
+    }
+
+    return SYMBOL_T;
+EOF
+
+    my $actual_output = expand($input);
+
+    is $actual_output, $expected_output, "expansion of fastfunc__all";
+}
+
+{
+    my $input = <<'EOF';
+    my ($bel, $f, $xs) = @_;
+
+    my ($x, $p);
+    ITERATE_FORWARD_OF($x, $p, $xs, sub {
+        IF(CALL($f, $x), sub {
+            return $p;
+        });
+    });
+
+    return NIL;
+EOF
+
+    my $expected_output = <<'EOF';
+    my ($bel, $f, $xs) = @_;
+
+    while (!is_nil($xs)) {
+        if (!is_nil($bel->call($f, $bel->car($xs)))) {
+            return $xs;
+        }
+        $xs = $bel->cdr($xs);
+    }
+
+    return SYMBOL_NIL;
+EOF
+
+    my $actual_output = expand($input);
+
+    is $actual_output, $expected_output, "expansion of fastfunc__some";
+}
+

--- a/t/preprocess-fastfuncs.t
+++ b/t/preprocess-fastfuncs.t
@@ -1,0 +1,32 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings;
+use Test::More;
+
+use Language::Bel::Globals::FastFuncs::Preprocessor qw(
+    preprocess
+);
+
+plan tests => 1;
+
+{
+    my $actual_fastfuncs;
+    {
+        open my $FASTFUNCS, "<", "lib/Language/Bel/Globals/FastFuncs.pm"
+            or die "Couldn't open fastfuncs module: $!";
+
+        my @lines;
+        while (my $line = <$FASTFUNCS>) {
+            push @lines, $line;
+        }
+
+        close $FASTFUNCS;
+
+        $actual_fastfuncs = join("", @lines);
+    }
+    my $generated_fastfuncs = preprocess();
+
+    is $actual_fastfuncs, $generated_fastfuncs, "the fastfuncs are up to date";
+}
+

--- a/t/preprocess-fastfuncs.t
+++ b/t/preprocess-fastfuncs.t
@@ -29,4 +29,3 @@ plan tests => 1;
 
     is $actual_fastfuncs, $generated_fastfuncs, "the fastfuncs are up to date";
 }
-

--- a/tools/generate-fastfuncs
+++ b/tools/generate-fastfuncs
@@ -1,0 +1,13 @@
+#!/usr/bin/perl
+use 5.006;
+use strict;
+use warnings;
+
+use Language::Bel::Globals::FastFuncs::Preprocessor qw(
+    generate_target_file
+);
+
+binmode STDOUT, ':encoding(utf-8)';
+
+generate_target_file();
+


### PR DESCRIPTION
<del>_Rebased on top of #260, which makes for a better base. Please merge that PR first. Kthx._</del> Merged. Rebased.

As attempted in #157. This represents a much more solid effort, albeit still with a fair bit of technical debt.

Pieces of debt I'd like to reduce:

- [ ] implement a "typechecker" that checks the sanity of the AST both after parsing and after each macro expansion
    - [ ] including checking that statements and expressions nest properly
    - [ ] including checking that `?` and `:` go together
- [ ] when there's a lexing or parsing error, show surrounding lines of context and a caret (`^`) under the failure
- [ ] maybe even same when there's a macro expansion error
- [ ] come up with a _much_ less noisy way to (quasi)quote new AST nodes in `Visitor.pm`
    - (I have an idea that can runtime-typecheck by using a syntax like `?variable`, and passing in the arguments
- [ ] maybe also something XPath-like to simplify the AST matching logic in `if` statements in that file
- [ ] maybe soak up the code duplication between `parse_argument_list` and `parse_variable_list`
- [ ] hide the "previous sibling" shenanigans behind a civilized API

None of these actually have to be handled before merge of this PR, only... eventually.

Closes #155, even though work remains to make it preprocess all of the fastfuncs.