### PR TITLE
Implement some number types

### DIFF
--- a/lib/Language/Bel/Type/Pair/Num.pm
+++ b/lib/Language/Bel/Type/Pair/Num.pm
@@ -1,0 +1,87 @@
+package Language::Bel::Type::Pair::Num;
+use base qw(Language::Bel::Type::Pair);
+
+use 5.006;
+use strict;
+use warnings;
+
+use Language::Bel::Types qw(
+    make_pair
+    make_symbol
+);
+use Language::Bel::Symbols::Common qw(
+    SYMBOL_NIL
+);
+
+use Exporter 'import';
+
+sub new {
+    my ($class, $real_sr, $imag_sr) = @_;
+
+    my $obj = {
+        real_sr => $real_sr,
+        imag_sr => $imag_sr,
+        pair => undef,
+    };
+    return bless($obj, $class);
+}
+
+sub reify_if_needed {
+    my ($self) = @_;
+
+    if (!$self->{pair}) {
+        $self->{pair} = make_pair(
+            make_symbol("lit"),
+            make_pair(
+                make_symbol("num"),
+                make_pair(
+                    $self->{real_sr},
+                    make_pair(
+                        $self->{imag_sr},
+                        SYMBOL_NIL,
+                    ),
+                ),
+            ),
+        );
+    }
+}
+
+sub car {
+    my ($self) = @_;
+
+    $self->reify_if_needed();
+    return $self->{pair}->car();
+}
+
+sub cdr {
+    my ($self) = @_;
+
+    $self->reify_if_needed();
+    return $self->{pair}->cdr();
+}
+
+sub xar {
+    my ($self, $car) = @_;
+
+    $self->reify_if_needed();
+    return $self->{pair}->xar($car);
+}
+
+sub xdr {
+    my ($self, $cdr) = @_;
+
+    $self->reify_if_needed();
+    return $self->{pair}->xdr($cdr);
+}
+
+sub make_num {
+    my ($real_sr, $imag_sr) = @_;
+
+    return __PACKAGE__->new($real_sr, $imag_sr);
+}
+
+our @EXPORT_OK = qw(
+    make_num
+);
+
+1;

--- a/lib/Language/Bel/Type/Pair/RepeatList.pm
+++ b/lib/Language/Bel/Type/Pair/RepeatList.pm
@@ -1,0 +1,85 @@
+package Language::Bel::Type::Pair::RepeatList;
+use base qw(Language::Bel::Type::Pair);
+
+use 5.006;
+use strict;
+use warnings;
+
+use Language::Bel::Types qw(
+    make_pair
+);
+use Language::Bel::Symbols::Common qw(
+    SYMBOL_NIL
+    SYMBOL_T
+);
+
+use Exporter 'import';
+
+sub new {
+    my ($class, $n) = @_;
+
+    my $obj = {
+        n => $n,
+        pair => undef,
+    };
+    return bless($obj, $class);
+}
+
+sub reify_if_needed {
+    my ($self) = @_;
+
+    if (!$self->{pair}) {
+        $self->{pair} = make_pair(
+            SYMBOL_T,
+            make_repeat_list($self->{n} - 1),
+        );
+    }
+}
+
+sub car {
+    my ($self) = @_;
+
+    $self->reify_if_needed();
+    return $self->{pair}->car();
+}
+
+sub cdr {
+    my ($self) = @_;
+
+    $self->reify_if_needed();
+    return $self->{pair}->cdr();
+}
+
+sub xar {
+    my ($self, $car) = @_;
+
+    $self->reify_if_needed();
+    return $self->{pair}->xar($car);
+}
+
+sub xdr {
+    my ($self, $cdr) = @_;
+
+    $self->reify_if_needed();
+    return $self->{pair}->xdr($cdr);
+}
+
+sub n {
+    my ($self) = @_;
+
+    return $self->{n};
+}
+
+sub make_repeat_list {
+    my ($n) = @_;
+
+    return $n > 0
+        ? __PACKAGE__->new($n)
+        : SYMBOL_NIL;
+}
+
+our @EXPORT_OK = qw(
+    make_repeat_list
+);
+
+1;

--- a/lib/Language/Bel/Type/Pair/SignedRat.pm
+++ b/lib/Language/Bel/Type/Pair/SignedRat.pm
@@ -1,0 +1,106 @@
+package Language::Bel::Type::Pair::SignedRat;
+use base qw(Language::Bel::Type::Pair);
+
+use 5.006;
+use strict;
+use warnings;
+
+use Language::Bel::Types qw(
+    make_pair
+    make_symbol
+);
+use Language::Bel::Type::Pair::RepeatList qw(
+    make_repeat_list
+);
+use Language::Bel::Symbols::Common qw(
+    SYMBOL_NIL
+);
+
+use Exporter 'import';
+
+sub new {
+    my ($class, $sign, $numerator, $denominator) = @_;
+
+    my $obj = {
+        sign => $sign,
+        numerator => $numerator,
+        denominator => $denominator,
+        pair => undef,
+    };
+    return bless($obj, $class);
+}
+
+sub reify_if_needed {
+    my ($self) = @_;
+
+    if (!$self->{pair}) {
+        $self->{pair} = make_pair(
+            make_symbol($self->{sign}),
+            make_pair(
+                make_repeat_list($self->{numerator}),
+                make_pair(
+                    make_repeat_list($self->{denominator}),
+                    SYMBOL_NIL,
+                ),
+            ),
+        );
+    }
+}
+
+sub car {
+    my ($self) = @_;
+
+    $self->reify_if_needed();
+    return $self->{pair}->car();
+}
+
+sub cdr {
+    my ($self) = @_;
+
+    $self->reify_if_needed();
+    return $self->{pair}->cdr();
+}
+
+sub xar {
+    my ($self, $car) = @_;
+
+    $self->reify_if_needed();
+    return $self->{pair}->xar($car);
+}
+
+sub xdr {
+    my ($self, $cdr) = @_;
+
+    $self->reify_if_needed();
+    return $self->{pair}->xdr($cdr);
+}
+
+sub sign {
+    my ($self) = @_;
+
+    return $self->{sign};
+}
+
+sub numerator {
+    my ($self) = @_;
+
+    return $self->{numerator};
+}
+
+sub denominator {
+    my ($self) = @_;
+
+    return $self->{denominator};
+}
+
+sub make_signed_rat {
+    my ($sign, $numerator, $denominator) = @_;
+
+    return __PACKAGE__->new($sign, $numerator, $denominator);
+}
+
+our @EXPORT_OK = qw(
+    make_signed_rat
+);
+
+1;


### PR DESCRIPTION
They're all subtypes of Pair, and are meant to be completely invisible from userspace:

- `Num`: a number
- `SignedRat`: a (sign, numerator, denominator) triple
- `RepeatList`: a list of one or more `t` symbols

Lays the groundwork for the speedups in #140, but doesn't actually provide those speedups yet. On the bright side, it doesn't slow things down or regress any tests, either.