### PR TITLE
Generate 'where' fastfuncs

### DIFF
--- a/lib/Language/Bel/Globals/FastFuncs.pm
+++ b/lib/Language/Bel/Globals/FastFuncs.pm
@@ -68,8 +68,7 @@ sub fastfunc__where__some {
     my ($bel, $f, $xs) = @_;
 
     while (!is_nil($xs)) {
-        my $p = $bel->call($f, $bel->car($xs));
-        if (!is_nil($p)) {
+        if (!is_nil($bel->call($f, $bel->car($xs)))) {
             return make_pair(
                 make_pair(
                     make_symbol("xs"),

--- a/lib/Language/Bel/Globals/FastFuncs/Source.pm
+++ b/lib/Language/Bel/Globals/FastFuncs/Source.pm
@@ -52,6 +52,7 @@ sub fastfunc__all {
     return T;
 }
 
+{[ GENERATE_WHERE ]}
 sub fastfunc__some {
     my ($bel, $f, $xs) = @_;
 
@@ -63,29 +64,6 @@ sub fastfunc__some {
     });
 
     return NIL;
-}
-
-sub fastfunc__where__some {
-    my ($bel, $f, $xs) = @_;
-
-    while (!is_nil($xs)) {
-        my $p = $bel->call($f, $bel->car($xs));
-        if (!is_nil($p)) {
-            return make_pair(
-                make_pair(
-                    make_symbol("xs"),
-                    $xs,
-                ),
-                make_pair(
-                    SYMBOL_D,
-                    SYMBOL_NIL,
-                ),
-            );
-        }
-        $xs = $bel->cdr($xs);
-    }
-
-    return SYMBOL_NIL;
 }
 
 sub fastfunc__reduce {

--- a/lib/Language/Bel/Globals/FastFuncs/Visitor.pm
+++ b/lib/Language/Bel/Globals/FastFuncs/Visitor.pm
@@ -407,8 +407,99 @@ sub visit {
     return $node;
 }
 
+sub visit_where {
+    my ($node) = @_;
+
+    if ($node->{type} eq "return_statement"
+        && $node->{children}[0]{type} eq "variable") {
+        my $variable = $node->{children}[0];
+        my $name = $variable->{name};
+        my $desigilled_name = substr($name, 1);
+        $node->{children}[0] = {
+            type => "call",
+            children => [
+                {
+                    type => "bareword",
+                    name => "make_pair",
+                },
+                {
+                    type => "argument_list",
+                    children => [
+                        {
+                            type => "call",
+                            children => [
+                                {
+                                    type => "bareword",
+                                    name => "make_pair",
+                                },
+                                {
+                                    type => "argument_list",
+                                    children => [
+                                        {
+                                            type => "call",
+                                            children => [
+                                                {
+                                                    type => "bareword",
+                                                    name => "make_symbol",
+                                                },
+                                                {
+                                                    type => "argument_list",
+                                                    children => [
+                                                        {
+                                                            type => "string",
+                                                            value => $desigilled_name,
+                                                        }
+                                                    ],
+                                                },
+                                            ],
+                                        },
+                                        $variable,
+                                    ],
+                                },
+                            ],
+                        },
+                        {
+                            type => "call",
+                            children => [
+                                {
+                                    type => "bareword",
+                                    name => "make_pair",
+                                },
+                                {
+                                    type => "argument_list",
+                                    children => [
+                                        {
+                                            type => "bareword",
+                                            name => "SYMBOL_D",
+                                        },
+                                        {
+                                            type => "bareword",
+                                            name => "SYMBOL_NIL",
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        };
+    }
+
+    my @children = exists $node->{children}
+        ? @{ $node->{children} }
+        : ();
+
+    for my $child (@children) {
+        $child = visit_where($child);
+    }
+
+    return $node;
+}
+
 our @EXPORT_OK = qw(
     visit
+    visit_where
 );
 
 1;


### PR DESCRIPTION
<del>_Built on top of #257, please merge that one first and rebase. Thanks._</del> Done.

Code-generates `where` functions out of their non-`where` counterparts. Also adds a little bit of argument list indentation for long expressions.