### PR TITLE
Normalize \r CR in fastfunc generator/test

### DIFF
--- a/lib/Language/Bel/Globals/FastFuncs/Preprocessor.pm
+++ b/lib/Language/Bel/Globals/FastFuncs/Preprocessor.pm
@@ -41,6 +41,8 @@ sub preprocess {
 
     my @result;
     while (my $line = <$SOURCE>) {
+        $line =~ s/\r//;
+
         next
             if $line =~ /^use Language::Bel::Globals::FastFuncs::Macros;$/;
 

--- a/t/preprocess-fastfuncs.t
+++ b/t/preprocess-fastfuncs.t
@@ -24,6 +24,7 @@ plan tests => 1;
         close $FASTFUNCS;
 
         $actual_fastfuncs = join("", @lines);
+        $actual_fastfuncs =~ s/\r//g;   # Windows likes these; we don't
     }
     my $generated_fastfuncs = preprocess();
 


### PR DESCRIPTION
This fixes a minor regression that I noticed after being back developing on Windows for the first time in a month or so.