### PR TITLE
Allow 'err' to be dynamically overridden

### DIFF
--- a/lib/Language/Bel.pm
+++ b/lib/Language/Bel.pm
@@ -745,7 +745,7 @@ FUT
                             $es2 = pair_cdr($es2);
                         }
 
-                        if ($self->{globals}->is_global_of_name($op, "err")) {
+                        if ($self->{globals}->is_original_err($op)) {
                             # XXX: Need to do proper parameter handling here
                             die _print($self->car($args)), "\n";
                         }

--- a/lib/Language/Bel.pm
+++ b/lib/Language/Bel.pm
@@ -102,12 +102,7 @@ sub new {
                 die "Fatal: could not find 'err'"
                     unless $err_kv && is_pair($err_kv);
                 my $err = $self->cdr($err_kv);
-                if ($self->{globals}->is_original_err($err)) {
-                    die _print($message_symbol), "\n";
-                }
-                else {
-                    $self->call($err, $message_symbol);
-                }
+                $self->call($err, $message_symbol);
             },
         });
     }
@@ -761,12 +756,7 @@ FUT
                             unshift @args, $arg;
                             $es2 = pair_cdr($es2);
                         }
-
-                        if ($self->{globals}->is_original_err($op)) {
-                            # XXX: Need to do proper parameter handling here
-                            die _print($self->car($args)), "\n";
-                        }
-                        elsif (is_fastfunc($op)) {
+                        if (is_fastfunc($op)) {
                             my $e;
                             if ($self->inwhere() && $op->handles_where()) {
                                 $e = $op->where_apply($self, @args);

--- a/lib/Language/Bel.pm
+++ b/lib/Language/Bel.pm
@@ -92,6 +92,23 @@ sub new {
     if (!defined($self->{primitives})) {
         $self->{primitives} = Language::Bel::Primitives->new({
             output => $self->{output},
+            err => sub {
+                my ($message_str) = @_;
+
+                my $message_symbol = make_symbol($message_str);
+                my $symbol_err = make_symbol("err");
+                # XXX: pass the lexical context
+                my $err_kv = $self->lookup($symbol_err, SYMBOL_NIL);
+                die "Fatal: could not find 'err'"
+                    unless $err_kv && is_pair($err_kv);
+                my $err = $self->cdr($err_kv);
+                if ($self->{globals}->is_original_err($err)) {
+                    die _print($message_symbol), "\n";
+                }
+                else {
+                    $self->call($err, $message_symbol);
+                }
+            },
         });
     }
     if (!defined($self->{globals})) {

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -141,7 +141,12 @@ sub new {
 
     $self = bless($self, $class);
     if (!defined($self->{primitives})) {
-        $self->{primitives} = Language::Bel::Primitives->new({ output => sub {} });
+        $self->{primitives} = Language::Bel::Primitives->new({
+            output => sub {},
+            err => sub {
+                die "Unexpected error while building globals",
+            },
+        });
     }
     if (!defined($self->{hash_ref}) && !defined($self->{list})) {
         $self->{hash_ref} = {};

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -7976,6 +7976,9 @@ sub new {
             make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
             make_pair(make_symbol("args"), make_pair(SYMBOL_NIL, SYMBOL_NIL))))));
     }
+    $self->{original_err} = $self->{primitives}->prim_cdr(
+        $self->{hash_ref}->{err}
+    );
 
     return $self;
 }
@@ -7992,6 +7995,12 @@ sub is_global_of_name {
     my $kv = $self->get_kv($global_name);
     my $global = pair_cdr($kv);
     return $global && are_identical($e, $global);
+}
+
+sub is_original_err {
+    my ($self, $e) = @_;
+
+    return are_identical($e, $self->{original_err});
 }
 
 # (let cell (cons v nil)

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -107,6 +107,7 @@ use Language::Bel::Globals::FastFuncs qw(
     fastfunc__prn
     fastfunc__pr
     fastfunc__prs
+    fastfunc__err
 );
 
 sub make_prim {
@@ -7977,9 +7978,10 @@ sub new {
             make_pair(make_symbol("inst-nontable"), SYMBOL_NIL)), SYMBOL_NIL)),
             SYMBOL_NIL)))))), SYMBOL_NIL))), SYMBOL_NIL))))));
 
-        $self->add_global("err", make_pair(make_symbol("lit"),
+        $self->add_global("err", make_fastfunc(make_pair(make_symbol("lit"),
             make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
-            make_pair(make_symbol("args"), make_pair(SYMBOL_NIL, SYMBOL_NIL))))));
+            make_pair(make_symbol("args"), make_pair(SYMBOL_NIL, SYMBOL_NIL))))),
+            \&fastfunc__err));
     }
     $self->{original_err} = $self->{primitives}->prim_cdr(
         $self->{hash_ref}->{err}
@@ -8000,12 +8002,6 @@ sub is_global_of_name {
     my $kv = $self->get_kv($global_name);
     my $global = pair_cdr($kv);
     return $global && are_identical($e, $global);
-}
-
-sub is_original_err {
-    my ($self, $e) = @_;
-
-    return are_identical($e, $self->{original_err});
 }
 
 # (let cell (cons v nil)

--- a/lib/Language/Bel/Globals/FastFuncs.pm
+++ b/lib/Language/Bel/Globals/FastFuncs.pm
@@ -22,7 +22,9 @@ use Language::Bel::Symbols::Common qw(
     SYMBOL_NIL
     SYMBOL_T
 );
-use Language::Bel::Printer;
+use Language::Bel::Printer qw(
+    _print
+);
 
 use Exporter 'import';
 
@@ -3682,6 +3684,12 @@ sub fastfunc__prs {
     return $result;
 }
 
+sub fastfunc__err {
+    my ($bel, $msg) = @_;
+
+    die _print($msg), "\n";
+}
+
 our @EXPORT_OK = qw(
     fastfunc__no
     fastfunc__atom
@@ -3764,6 +3772,7 @@ our @EXPORT_OK = qw(
     fastfunc__prn
     fastfunc__pr
     fastfunc__prs
+    fastfunc__err
 );
 
 1;

--- a/lib/Language/Bel/Globals/FastFuncs/Source.pm
+++ b/lib/Language/Bel/Globals/FastFuncs/Source.pm
@@ -22,7 +22,9 @@ use Language::Bel::Symbols::Common qw(
     SYMBOL_NIL
     SYMBOL_T
 );
-use Language::Bel::Printer;
+use Language::Bel::Printer qw(
+    _print
+);
 use Language::Bel::Globals::FastFuncs::Macros;
 
 use Exporter 'import';
@@ -3662,6 +3664,12 @@ sub fastfunc__prs {
     return $result;
 }
 
+sub fastfunc__err {
+    my ($bel, $msg) = @_;
+
+    die _print($msg), "\n";
+}
+
 our @EXPORT_OK = qw(
     fastfunc__no
     fastfunc__atom
@@ -3744,6 +3752,7 @@ our @EXPORT_OK = qw(
     fastfunc__prn
     fastfunc__pr
     fastfunc__prs
+    fastfunc__err
 );
 
 1;

--- a/lib/Language/Bel/Globals/Generator.pm
+++ b/lib/Language/Bel/Globals/Generator.pm
@@ -466,12 +466,6 @@ sub is_global_of_name {
     return $global && are_identical($e, $global);
 }
 
-sub is_original_err {
-    my ($self, $e) = @_;
-
-    return are_identical($e, $self->{original_err});
-}
-
 # (let cell (cons v nil)
 #   (xdr g (cons cell (cdr g)))
 #   cell)))

--- a/lib/Language/Bel/Globals/Generator.pm
+++ b/lib/Language/Bel/Globals/Generator.pm
@@ -151,7 +151,12 @@ sub new {
 
     $self = bless($self, $class);
     if (!defined($self->{primitives})) {
-        $self->{primitives} = Language::Bel::Primitives->new({ output => sub {} });
+        $self->{primitives} = Language::Bel::Primitives->new({
+            output => sub {},
+            err => sub {
+                die "Unexpected error while building globals",
+            },
+        });
     }
     if (!defined($self->{hash_ref}) && !defined($self->{list})) {
         $self->{hash_ref} = {};

--- a/lib/Language/Bel/Globals/Generator.pm
+++ b/lib/Language/Bel/Globals/Generator.pm
@@ -440,6 +440,9 @@ HEADER
 
     print <<'FOOTER';
     }
+    $self->{original_err} = $self->{primitives}->prim_cdr(
+        $self->{hash_ref}->{err}
+    );
 
     return $self;
 }
@@ -456,6 +459,12 @@ sub is_global_of_name {
     my $kv = $self->get_kv($global_name);
     my $global = pair_cdr($kv);
     return $global && are_identical($e, $global);
+}
+
+sub is_original_err {
+    my ($self, $e) = @_;
+
+    return are_identical($e, $self->{original_err});
 }
 
 # (let cell (cons v nil)

--- a/lib/Language/Bel/Primitives.pm
+++ b/lib/Language/Bel/Primitives.pm
@@ -42,6 +42,9 @@ sub new {
     if (!defined($self->{output}) || ref($self->{output}) ne "CODE") {
         die "Named parameter 'output' of type CODE required";
     }
+    if (!defined($self->{err}) || ref($self->{err}) ne "CODE") {
+        die "Named parameter 'err' of type CODE required";
+    }
     if (!defined($self->{wrb_buffer_of})) {
         $self->{wrb_buffer_of} = {
             nil => []
@@ -57,7 +60,7 @@ sub prim_car {
         return SYMBOL_NIL;
     }
     elsif (!is_pair($object)) {
-        die "car-on-atom\n";
+        $self->{err}->("car-on-atom");
     }
     else {
         return pair_car($object);

--- a/lib/Language/Bel/Primitives.pm
+++ b/lib/Language/Bel/Primitives.pm
@@ -60,7 +60,7 @@ sub prim_car {
         return SYMBOL_NIL;
     }
     elsif (!is_pair($object)) {
-        $self->{err}->("car-on-atom");
+        return $self->{err}->("car-on-atom");
     }
     else {
         return pair_car($object);
@@ -74,7 +74,7 @@ sub prim_cdr {
         return SYMBOL_NIL;
     }
     elsif (!is_pair($object)) {
-        $self->{err}->("cdr-on-atom");
+        return $self->{err}->("cdr-on-atom");
     }
     else {
         return pair_cdr($object);
@@ -89,7 +89,7 @@ sub prim_cls {
         return $stream;
     }
     else {
-        $self->{err}->("mistype");
+        return $self->{err}->("mistype");
     }
 }
 
@@ -125,7 +125,7 @@ sub prim_nom {
         return $result;
     }
     else {
-        $self->{err}->("mistype");
+        return $self->{err}->("mistype");
     }
 }
 
@@ -135,13 +135,13 @@ sub prim_ops {
     my @stack;
     while (is_pair($path)) {
         my $elem = pair_car($path);
-        $self->{err}->("mistype") && return
+        return $self->{err}->("mistype")
             unless is_char($elem);
         push @stack, chr(char_codepoint($elem));
         $path = pair_cdr($path);
     }
     if (!is_nil($path)) {
-        $self->{err}->("mistype");
+        return $self->{err}->("mistype");
     }
     else {
         my $path_str = join("", @stack);
@@ -151,7 +151,7 @@ sub prim_ops {
             return make_stream($path_str, $mode);
         }
         else {
-            $self->{err}->("mistype");
+            return $self->{err}->("mistype");
         }
     }
 

--- a/lib/Language/Bel/Primitives.pm
+++ b/lib/Language/Bel/Primitives.pm
@@ -245,7 +245,7 @@ sub prim_wrb {
                 || $codepoint == ord("1"));
     return $self->{err}->("mistype")
         unless is_nil($stream) || is_stream($stream);
-    die "'badmode\n"
+    return $self->{err}->("badmode")
         if is_stream($stream) && $stream->mode() ne "out";
 
     my $n = is_char($bit) && $codepoint eq ord("1") ? 1 : 0;

--- a/lib/Language/Bel/Primitives.pm
+++ b/lib/Language/Bel/Primitives.pm
@@ -135,18 +135,27 @@ sub prim_ops {
     my @stack;
     while (is_pair($path)) {
         my $elem = pair_car($path);
-        die "not-a-string"
+        $self->{err}->("mistype") && return
             unless is_char($elem);
         push @stack, chr(char_codepoint($elem));
         $path = pair_cdr($path);
     }
-    my $path_str = join("", @stack);
+    if (!is_nil($path)) {
+        $self->{err}->("mistype");
+    }
+    else {
+        my $path_str = join("", @stack);
 
-    if (!is_symbol($mode)) {
-        die "not-a-symbol\n";
+        if (is_symbol($mode) &&
+            (symbol_name($mode) eq "in" || symbol_name($mode) eq "out")) {
+            return make_stream($path_str, $mode);
+        }
+        else {
+            $self->{err}->("mistype");
+        }
     }
 
-    return make_stream($path_str, $mode);
+    return SYMBOL_NIL;
 }
 
 my $CHAR_0 = make_char(ord("0"));

--- a/lib/Language/Bel/Primitives.pm
+++ b/lib/Language/Bel/Primitives.pm
@@ -243,7 +243,7 @@ sub prim_wrb {
         unless is_char($bit)
             && (($codepoint = char_codepoint($bit)) == ord("0")
                 || $codepoint == ord("1"));
-    die "'mistype\n"
+    return $self->{err}->("mistype")
         unless is_nil($stream) || is_stream($stream);
     die "'badmode\n"
         if is_stream($stream) && $stream->mode() ne "out";

--- a/lib/Language/Bel/Primitives.pm
+++ b/lib/Language/Bel/Primitives.pm
@@ -74,7 +74,7 @@ sub prim_cdr {
         return SYMBOL_NIL;
     }
     elsif (!is_pair($object)) {
-        die "cdr-on-atom\n";
+        $self->{err}->("cdr-on-atom");
     }
     else {
         return pair_cdr($object);

--- a/lib/Language/Bel/Primitives.pm
+++ b/lib/Language/Bel/Primitives.pm
@@ -164,7 +164,7 @@ my $CHAR_1 = make_char(ord("1"));
 sub prim_rdb {
     my ($self, $stream) = @_;
 
-    die "'mistype\n"
+    return $self->{err}->("mistype")
         unless is_nil($stream) || is_stream($stream);
     die "XXX: can't handle nil stream just yet"
         if is_nil($stream);

--- a/lib/Language/Bel/Primitives.pm
+++ b/lib/Language/Bel/Primitives.pm
@@ -168,7 +168,7 @@ sub prim_rdb {
         unless is_nil($stream) || is_stream($stream);
     die "XXX: can't handle nil stream just yet"
         if is_nil($stream);
-    die "'badmode\n"
+    return $self->{err}->("badmode")
         if is_stream($stream) && $stream->mode() ne "in";
 
     my $rdb_buffer = is_nil($stream)

--- a/lib/Language/Bel/Primitives.pm
+++ b/lib/Language/Bel/Primitives.pm
@@ -203,12 +203,12 @@ sub prim_sym {
     my @stack;
     while (is_pair($value)) {
         my $elem = pair_car($value);
-        die "not-a-string"
+        return $self->{err}->("mistype")
             unless is_char($elem);
         push @stack, chr(char_codepoint($elem));
         $value = pair_cdr($value);
     }
-    die "not-a-string"
+    return $self->{err}->("mistype")
         unless is_nil($value);
 
     my $name = join("", @stack);

--- a/lib/Language/Bel/Primitives.pm
+++ b/lib/Language/Bel/Primitives.pm
@@ -272,9 +272,9 @@ sub prim_wrb {
 sub prim_xar {
     my ($self, $object, $a_value) = @_;
 
-    if (!is_pair($object)) {
-        die "xar-on-atom\n";
-    }
+    return $self->{err}->("xar-on-atom")
+        unless is_pair($object);
+
     pair_set_car($object, $a_value);
     return $a_value;
 }
@@ -282,9 +282,9 @@ sub prim_xar {
 sub prim_xdr {
     my ($self, $object, $d_value) = @_;
 
-    if (!is_pair($object)) {
-        die "xdr-on-atom\n";
-    }
+    return $self->{err}->("xdr-on-atom")
+        unless is_pair($object);
+
     pair_set_cdr($object, $d_value);
     return $d_value;
 }

--- a/lib/Language/Bel/Primitives.pm
+++ b/lib/Language/Bel/Primitives.pm
@@ -114,18 +114,19 @@ sub prim_join {
 sub prim_nom {
     my ($self, $value) = @_;
 
-    if (!is_symbol($value)) {
-        die "not-a-symbol\n";
+    if (is_symbol($value)) {
+        my $result = SYMBOL_NIL;
+        for my $char (reverse(split //, symbol_name($value))) {
+            $result = make_pair(
+                make_char(ord($char)),
+                $result,
+            );
+        }
+        return $result;
     }
-
-    my $result = SYMBOL_NIL;
-    for my $char (reverse(split //, symbol_name($value))) {
-        $result = make_pair(
-            make_char(ord($char)),
-            $result,
-        );
+    else {
+        $self->{err}->("mistype");
     }
-    return $result;
 }
 
 sub prim_ops {

--- a/lib/Language/Bel/Primitives.pm
+++ b/lib/Language/Bel/Primitives.pm
@@ -191,7 +191,7 @@ sub prim_rdb {
 sub prim_stat {
     my ($self, $stream) = @_;
 
-    die "'mistype\n"
+    return $self->{err}->("mistype")
         unless is_stream($stream);
 
     return make_symbol($stream->stat());

--- a/lib/Language/Bel/Primitives.pm
+++ b/lib/Language/Bel/Primitives.pm
@@ -84,11 +84,13 @@ sub prim_cdr {
 sub prim_cls {
     my ($self, $stream) = @_;
 
-    die "'mistype\n"
-        unless is_stream($stream);
-
-    $stream->close();
-    return $stream;
+    if (is_stream($stream)) {
+        $stream->close();
+        return $stream;
+    }
+    else {
+        $self->{err}->("mistype");
+    }
 }
 
 sub prim_coin {

--- a/lib/Language/Bel/Primitives.pm
+++ b/lib/Language/Bel/Primitives.pm
@@ -239,10 +239,10 @@ sub prim_wrb {
     my ($self, $bit, $stream) = @_;
 
     my $codepoint;
-    die "'mistype\n"
+    return $self->{err}->("mistype")
         unless is_char($bit)
-            && ($codepoint = char_codepoint($bit)) == ord("0")
-                || $codepoint == ord("1");
+            && (($codepoint = char_codepoint($bit)) == ord("0")
+                || $codepoint == ord("1"));
     die "'mistype\n"
         unless is_nil($stream) || is_stream($stream);
     die "'badmode\n"

--- a/t/02-prim-rdb.t
+++ b/t/02-prim-rdb.t
@@ -35,7 +35,7 @@ eof
 
 > (let s (ops "temp3627" 'out)
     (rdb s))
-!ERROR: 'badmode
+!ERROR: badmode
 
 !END: unlink("temp3627");
 

--- a/t/fn-bel-prim-nom.t
+++ b/t/fn-bel-prim-nom.t
@@ -10,14 +10,14 @@ __DATA__
 "a"
 
 > (bel '(nom \a))
-!ERROR: not-a-symbol
+!ERROR: mistype
 
 > (bel '(nom nil))
 "nil"
 
 > (bel '(nom '(a)))
-!ERROR: not-a-symbol
+!ERROR: mistype
 
 > (bel '(nom "a"))
-!ERROR: not-a-symbol
+!ERROR: mistype
 

--- a/t/overriding-err.t
+++ b/t/overriding-err.t
@@ -73,3 +73,11 @@ hi-from-err
     n)
 mistype
 
+> (let n nil
+    (dyn err (fn (msg) (set n msg))
+      (let s (ops "temp9832" 'out)
+        (rdb s)))
+    n)
+badmode
+
+!END: unlink("temp9832");

--- a/t/overriding-err.t
+++ b/t/overriding-err.t
@@ -63,3 +63,7 @@ mistype
     n)
 mistype
 
+> (dyn err (fn (msg) 'hi-from-err)
+    (car 'nonpair))
+hi-from-err
+

--- a/t/overriding-err.t
+++ b/t/overriding-err.t
@@ -100,3 +100,9 @@ mistype
     n)
 mistype
 
+> (let n nil
+    (dyn err (fn (msg) (set n msg))
+      (wrb 'nonbit nil))
+    n)
+mistype
+

--- a/t/overriding-err.t
+++ b/t/overriding-err.t
@@ -39,3 +39,9 @@ cdr-on-atom
     n)
 mistype
 
+> (let n nil
+    (dyn err (fn (msg) (set n msg))
+      (nom "nonsymbol"))
+    n)
+mistype
+

--- a/t/overriding-err.t
+++ b/t/overriding-err.t
@@ -112,3 +112,10 @@ mistype
     n)
 mistype
 
+> (let n nil
+    (dyn err (fn (msg) (set n msg))
+      (let s (ops "README.md" 'in)
+        (wrb \0 s)))
+    n)
+badmode
+

--- a/t/overriding-err.t
+++ b/t/overriding-err.t
@@ -67,3 +67,9 @@ mistype
     (car 'nonpair))
 hi-from-err
 
+> (let n nil
+    (dyn err (fn (msg) (set n msg))
+      (rdb 'nonstream))
+    n)
+mistype
+

--- a/t/overriding-err.t
+++ b/t/overriding-err.t
@@ -1,0 +1,15 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings;
+use Language::Bel::Test::DSL;
+
+__DATA__
+
+> (def err args
+    'overridden)
+!IGNORE: result of definition
+
+> (err 'something)
+overridden
+

--- a/t/overriding-err.t
+++ b/t/overriding-err.t
@@ -27,3 +27,9 @@ But you cannot override `err` lexically.
     n)
 nil
 
+> (let n nil
+    (dyn err (fn args (set n t))
+      (cdr 'nonpair))
+    n)
+t
+

--- a/t/overriding-err.t
+++ b/t/overriding-err.t
@@ -14,28 +14,28 @@ __DATA__
 overridden
 
 > (let n nil
-    (dyn err (fn args (set n t))
+    (dyn err (fn (msg) (set n msg))
       (car 'nonpair))
     n)
-t
+car-on-atom
 
 But you cannot override `err` lexically.
 
 > (let n nil
-    (let err (fn args (set n t))
+    (let err (fn (msg) (set n msg))
       (car 'nonpair))
     n)
 nil
 
 > (let n nil
-    (dyn err (fn args (set n t))
+    (dyn err (fn (msg) (set n msg))
       (cdr 'nonpair))
     n)
-t
+cdr-on-atom
 
 > (let n nil
-    (dyn err (fn args (set n t))
+    (dyn err (fn (msg) (set n msg))
       (cls 'nonstream))
     n)
-t
+mistype
 

--- a/t/overriding-err.t
+++ b/t/overriding-err.t
@@ -119,3 +119,15 @@ mistype
     n)
 badmode
 
+> (let n nil
+    (dyn err (fn (msg) (set n msg))
+      (xar 'nonpair 'a))
+    n)
+xar-on-atom
+
+> (let n nil
+    (dyn err (fn (msg) (set n msg))
+      (xdr 'nonpair 'd))
+    n)
+xdr-on-atom
+

--- a/t/overriding-err.t
+++ b/t/overriding-err.t
@@ -19,3 +19,11 @@ overridden
     n)
 t
 
+But you cannot override `err` lexically.
+
+> (let n nil
+    (let err (fn args (set n t))
+      (car 'nonpair))
+    n)
+nil
+

--- a/t/overriding-err.t
+++ b/t/overriding-err.t
@@ -13,3 +13,9 @@ __DATA__
 > (err 'something)
 overridden
 
+> (let n nil
+    (dyn err (fn args (set n t))
+      (car 'nonpair))
+    n)
+t
+

--- a/t/overriding-err.t
+++ b/t/overriding-err.t
@@ -45,3 +45,21 @@ mistype
     n)
 mistype
 
+> (let n nil
+    (dyn err (fn (msg) (set n msg))
+      (ops 'nonstring 'out))
+    n)
+mistype
+
+> (let n nil
+    (dyn err (fn (msg) (set n msg))
+      (ops "some-file" "nonsymbol"))
+    n)
+mistype
+
+> (let n nil
+    (dyn err (fn (msg) (set n msg))
+      (ops "some-file" 'neither-in-or-out))
+    n)
+mistype
+

--- a/t/overriding-err.t
+++ b/t/overriding-err.t
@@ -33,3 +33,9 @@ nil
     n)
 t
 
+> (let n nil
+    (dyn err (fn args (set n t))
+      (cls 'nonstream))
+    n)
+t
+

--- a/t/overriding-err.t
+++ b/t/overriding-err.t
@@ -106,3 +106,9 @@ mistype
     n)
 mistype
 
+> (let n nil
+    (dyn err (fn (msg) (set n msg))
+      (wrb \0 'nonstream))
+    n)
+mistype
+

--- a/t/overriding-err.t
+++ b/t/overriding-err.t
@@ -88,3 +88,15 @@ badmode
     n)
 mistype
 
+> (let n nil
+    (dyn err (fn (msg) (set n msg))
+      (sym 'nonstring))
+    n)
+mistype
+
+> (let n nil
+    (dyn err (fn (msg) (set n msg))
+      (sym '(\a \b \c . \d)))
+    n)
+mistype
+

--- a/t/overriding-err.t
+++ b/t/overriding-err.t
@@ -81,3 +81,10 @@ mistype
 badmode
 
 !END: unlink("temp9832");
+
+> (let n nil
+    (dyn err (fn (msg) (set n msg))
+      (stat 'nonstream))
+    n)
+mistype
+

--- a/t/prim-cls.t
+++ b/t/prim-cls.t
@@ -19,7 +19,7 @@ closed
 !ERROR: 'already-closed
 
 > (cls 'not-a-stream)
-!ERROR: 'mistype
+!ERROR: mistype
 
 !END: unlink("testfile");
 

--- a/t/prim-nom.t
+++ b/t/prim-nom.t
@@ -10,14 +10,14 @@ __DATA__
 "a"
 
 > (nom \a)
-!ERROR: not-a-symbol
+!ERROR: mistype
 
 > (nom nil)
 "nil"
 
 > (nom '(a))
-!ERROR: not-a-symbol
+!ERROR: mistype
 
 > (nom "a")
-!ERROR: not-a-symbol
+!ERROR: mistype
 


### PR DESCRIPTION
This one is ready to merge now. All the errors that can happen in primitives are re-routed such that the run a dynamic `err` if one is bound.

As a bonus, `err` is no longer a special case in the interpreter &mdash; it's just a fastfunc. This is clearly a win.

Work remains, however. There's a strong case that something like a `mistype` or `overargs` issued by the interpreter should also be re-routed to a dynamic `err`. This can come later, however. Better to merge this first.