### PR TITLE
Hide diagnostic test output

### DIFF
--- a/lib/Language/Bel/Test/DSL.pm
+++ b/lib/Language/Bel/Test/DSL.pm
@@ -246,11 +246,15 @@ CHECK {
             }
         }
         elsif ($item->{type} eq "DIAGNOSTIC") {
-            diag($item->{text});
+            if ($ENV{BEL_TEST_DIAG}) {
+                diag($item->{text});
+            }
         }
         elsif ($item->{type} eq "DIRECTIVE" && $item->{name} eq "TODO") {
             $todo_toggle = 1;
-            diag($item->{payload});
+            if ($ENV{BEL_TEST_DIAG}) {
+                diag($item->{payload});
+            }
         }
         # everything else, we ignore
     }


### PR DESCRIPTION
By default. If you want to opt back in, there's an environment
variable.