### PR TITLE
Add missing closing ')' in tests

### DIFF
--- a/lib/Language/Bel/Reader.pm
+++ b/lib/Language/Bel/Reader.pm
@@ -182,12 +182,14 @@ sub _rdlist {
     ++$pos;
     my @list;
     my $seen_dot = "";
+    my $seen_stopper = "";
     my $seen_element_after_dot = "";
     while ($pos < length($expr)) {
         $skip_whitespace->();
         my $c = substr($expr, $pos, 1);
         if ($c eq $stopper) {
             ++$pos;
+            $seen_stopper = 1;
             last;
         }
         elsif ($c eq ".") {
@@ -211,6 +213,8 @@ sub _rdlist {
         push @list, $r->{ast};
         $pos = $r->{pos};
     }
+    die "Expected '$stopper', got end of input\n"
+        unless $seen_stopper;
     my $ast = $seen_dot ? pop(@list) : SYMBOL_NIL;
     for my $e (reverse(@list)) {
         $ast = make_pair($e, $ast);

--- a/t/01-virfns.t
+++ b/t/01-virfns.t
@@ -26,7 +26,7 @@ x
 x
 
 > (set tab (table '((a . 1)
-                    (b . 2)))
+                    (b . 2))))
 !IGNORE: result of assignment
 
 > (tab 'a)

--- a/t/02-mac-zap.t
+++ b/t/02-mac-zap.t
@@ -24,7 +24,7 @@ __DATA__
 > y
 "Bel"
 
-> (set L '(a b c)
+> (set L '(a b c))
 (a b c)
 
 > (zap (fn () 'z) (cadr L))

--- a/t/fn-bel-sigerr.t
+++ b/t/fn-bel-sigerr.t
@@ -54,7 +54,7 @@ __DATA__
 > (bel '(no))
 !ERROR: underargs
 
-> (bel '((lit clo nil ((x y)) nil) 'd)
+> (bel '((lit clo nil ((x y)) nil) 'd))
 !ERROR: atom-arg
 
 > (bel '(join 'a (ccc (lit clo nil (c) (c)))))

--- a/t/form-apply.t
+++ b/t/form-apply.t
@@ -24,6 +24,6 @@ nil
 > (apply cons '())
 nil
 
-> (map apply (list (fn () 'x) (fn () 'y))
+> (map apply (list (fn () 'x) (fn () 'y)))
 (x y)
 

--- a/t/form-where.t
+++ b/t/form-where.t
@@ -60,7 +60,7 @@ bye
 > (where (some pair '(a b (c d) e)))
 ((xs (c d) e) d)
 
-> (where (some symbol '((a b) c d e)
+> (where (some symbol '((a b) c d e)))
 ((xs c d e) d)
 
 > (where (mem 'b '(a b c)))

--- a/t/mac-clean.t
+++ b/t/mac-clean.t
@@ -6,7 +6,7 @@ use Language::Bel::Test::DSL;
 
 __DATA__
 
-> (set x '(1 2 3 4 5)
+> (set x '(1 2 3 4 5))
 (1 2 3 4 5)
 
 > (clean odd x)


### PR DESCRIPTION
These missing cases were discovered when switching out the regular reader, implemented in Perl, with one implemented in Bel.