### PR TITLE
Update copyright year

### DIFF
--- a/README
+++ b/README
@@ -45,7 +45,7 @@ You can also look for information at:
 
 LICENSE AND COPYRIGHT
 
-This software is Copyright (c) 2019-2020 by Carl Mäsak.
+This software is Copyright (c) 2019-2021 by Carl Mäsak.
 
 This program is released under the following license:
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Pull requests are warmly welcome.
 
 ## License and copyright
 
-This software is Copyright (c) 2019-2020 by Carl Mäsak.
+This software is Copyright (c) 2019-2021 by Carl Mäsak.
 
 This project is licensed under the GNU GPL 3.0.
 For details, see [`LICENSE`](https://github.com/masak/bel/blob/master/LICENSE).

--- a/lib/Language/Bel.pm
+++ b/lib/Language/Bel.pm
@@ -1500,7 +1500,7 @@ L<https://metacpan.org/release/Language-Bel>
 
 =head1 LICENSE AND COPYRIGHT
 
-This software is Copyright (c) 2019-2020 by Carl Mäsak.
+This software is Copyright (c) 2019-2021 by Carl Mäsak.
 
 This program is released under the following license:
 


### PR DESCRIPTION
Tests which spontaneously start to fail aren't so good, but for `t/copyright-year.t` I'm willing to make an exception. I doubt I would've remembered to update the copyright year this soon otherwise.