### PR TITLE
Add test file for odd 'hug' calls

### DIFF
--- a/t/odd-hugs.t
+++ b/t/odd-hugs.t
@@ -1,0 +1,33 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings;
+use Language::Bel::Test::DSL;
+
+__DATA__
+
+> (hug '(a b c d e))
+((a b) (c d) (e))
+
+> (with (a 1 b) (list a b))
+(1 nil)
+
+> (set x 1
+       y)
+t
+
+> x
+1
+
+> y
+t
+
+> (tem t1 f1 nil f2)
+!ERROR: 'underargs
+
+> (tem t2 f1 nil)
+!IGNORE: result of template declaration
+
+> (make t2 f1 1 f2)
+!ERROR: 'underargs
+


### PR DESCRIPTION
The `hug` function itself takes a list like `(a b c d)` and gives back a list of 2-element lists: `((a b) (c d))`. Good for pairing things up. This function itself is tolerant to an odd, unpaired element at the end: `(a b c d e)` gives back `((a b) (c d) (e))`.

But built-in functions and macros that use `hug` vary in their tolerance to odd-length lists. Many of them have a default, like `nil` or `t` (which we test here); others simply fail by giving a more or less cryptic `underargs` error (which we also test).