### PR TITLE
Add two test cases for dangling

### DIFF
--- a/t/mac-with.t
+++ b/t/mac-with.t
@@ -12,3 +12,6 @@ __DATA__
 > (let x 'a (with (x 'b y x) y))
 a
 
+> (with (x 'a y) y)
+nil
+

--- a/t/mac-withs.t
+++ b/t/mac-withs.t
@@ -28,3 +28,7 @@ when evaluating the expression to be bound.
       y))
 a
 
+> (withs (x 'a y)
+    (cons x y))
+(a)
+


### PR DESCRIPTION
Both `with` and `withs` can take a variable with no corresponding
value bound, in which case the value is nil.

Closes #314.