### PR TITLE
Add a fast path for getting integers

### DIFF
--- a/lib/Language/Bel/Pair/RepeatList.pm
+++ b/lib/Language/Bel/Pair/RepeatList.pm
@@ -68,6 +68,12 @@ sub n {
     return $self->{n};
 }
 
+sub is_repeat_list {
+    my ($object) = @_;
+
+    return $object->isa(__PACKAGE__);
+}
+
 sub make_repeat_list {
     my ($n) = @_;
 
@@ -77,7 +83,9 @@ sub make_repeat_list {
 }
 
 our @EXPORT_OK = qw(
+    is_repeat_list
     make_repeat_list
+    n
 );
 
 1;

--- a/lib/Language/Bel/Pair/SignedRat.pm
+++ b/lib/Language/Bel/Pair/SignedRat.pm
@@ -91,6 +91,12 @@ sub denominator {
     return $self->{denominator};
 }
 
+sub is_signed_rat {
+    my ($object) = @_;
+
+    return $object->isa(__PACKAGE__);
+}
+
 sub make_signed_rat {
     my ($sign, $numerator, $denominator) = @_;
 
@@ -98,7 +104,11 @@ sub make_signed_rat {
 }
 
 our @EXPORT_OK = qw(
+    denominator
+    is_signed_rat
     make_signed_rat
+    numerator
+    sign
 );
 
 1;


### PR DESCRIPTION
Is it an internal `Num` object (all the way down)? Then we exploit
that to not have to iterate down any repeated cons lists.