### PR TITLE
Implement a bytecode runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ After downloading Bel, you can run it like this:
 
 ```sh
 $ perl -Ilib bin/bel
-Language::Bel 0.54 -- darwin.
+Language::Bel 0.55 -- darwin.
 >
 > ;; loops
 > (set n (len (apply append prims)))

--- a/lib/Language/Bel.pm
+++ b/lib/Language/Bel.pm
@@ -47,11 +47,11 @@ Language::Bel - An interpreter for Paul Graham's language Bel
 
 =head1 VERSION
 
-Version 0.54
+Version 0.55
 
 =cut
 
-our $VERSION = '0.54';
+our $VERSION = '0.55';
 
 =head1 SYNOPSIS
 

--- a/lib/Language/Bel.pm
+++ b/lib/Language/Bel.pm
@@ -23,6 +23,9 @@ use Language::Bel::Core qw(
     SYMBOL_LOCK
     SYMBOL_NIL
 );
+use Language::Bel::Pair::ByteFunc qw(
+    is_bytefunc
+);
 use Language::Bel::Pair::FastFunc qw(
     is_fastfunc
 );
@@ -139,6 +142,9 @@ sub call {
     my ($self, $fn, @args) = @_;
 
     if (is_fastfunc($fn)) {
+        return $fn->apply($self, @args);
+    }
+    elsif (is_bytefunc($fn)) {
         return $fn->apply($self, @args);
     }
     else {
@@ -891,6 +897,10 @@ FUT
                             else {
                                 $e = $op->apply($self, @args);
                             }
+                            push @{$self->{r}}, $e;
+                        }
+                        elsif (is_bytefunc($op)) {
+                            my $e = $op->apply($self, @args);
                             push @{$self->{r}}, $e;
                         }
                         else {

--- a/lib/Language/Bel.pm
+++ b/lib/Language/Bel.pm
@@ -145,6 +145,7 @@ sub call {
         return $fn->apply($self, @args);
     }
     elsif (is_bytefunc($fn)) {
+        die "Can't `call` a bytefunc";
         return $fn->apply($self, @args);
     }
     else {
@@ -900,7 +901,7 @@ FUT
                             push @{$self->{r}}, $e;
                         }
                         elsif (is_bytefunc($op)) {
-                            my $e = $op->apply($self, @args);
+                            my $e = $op->apply($self, $args);
                             push @{$self->{r}}, $e;
                         }
                         else {

--- a/lib/Language/Bel/Bytecode.pm
+++ b/lib/Language/Bel/Bytecode.pm
@@ -1,0 +1,41 @@
+package Language::Bel::Bytecode;
+
+use 5.006;
+use strict;
+use warnings;
+
+use Exporter 'import';
+
+sub PARAM_IN { 0x00 }
+sub PARAM_NEXT { 0x01 }
+sub SET_PARAM_NEXT { 0x02 }
+sub PARAM_LAST { 0x03 }
+sub PARAM_OUT { 0x04 }
+
+sub SET_PRIM_ID_REG_SYM { 0x10 }
+sub SET_PRIM_TYPE_REG { 0x11 }
+
+sub RETURN_REG { 0xF0 }
+
+sub SYM_NIL { 0 }
+sub SYM_T { 1 }
+sub SYM_PAIR { 2 }
+
+sub n { 0 }
+
+our @EXPORT_OK = qw(
+    n
+    PARAM_IN
+    PARAM_LAST
+    PARAM_NEXT
+    PARAM_OUT
+    RETURN_REG
+    SET_PARAM_NEXT
+    SET_PRIM_ID_REG_SYM
+    SET_PRIM_TYPE_REG
+    SYM_NIL
+    SYM_T
+    SYM_PAIR
+);
+
+1;

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -11,6 +11,7 @@ use Language::Bel::Core qw(
     make_pair
     make_symbol
     pair_cdr
+    pair_set_cdr
     symbol_name
     SYMBOL_CHAR
     SYMBOL_NIL
@@ -18,6 +19,9 @@ use Language::Bel::Core qw(
     SYMBOL_QUOTE
     SYMBOL_SYMBOL
     SYMBOL_T
+);
+use Language::Bel::Pair::ByteFunc qw(
+    make_bytefunc
 );
 use Language::Bel::Pair::FastFunc qw(
     make_fastfunc
@@ -8807,6 +8811,16 @@ sub new {
             make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
             make_pair(make_symbol("args"), make_pair(SYMBOL_NIL, SYMBOL_NIL))))),
             \&fastfunc__err));
+
+        $self->add_global("bcfn", make_pair(make_symbol("lit"),
+            make_pair(make_symbol("tab"), SYMBOL_NIL)));
+        pair_set_cdr(
+            pair_cdr(pair_cdr($self->{hash_ref}->{bcfn})),
+            make_pair(
+                make_pair(make_symbol("no"), make_bytefunc(1, [])),
+                pair_cdr(pair_cdr(pair_cdr($self->{hash_ref}->{bcfn}))),
+            ),
+        );
     }
     $self->{original_err} = $self->{primitives}->prim_cdr(
         $self->{hash_ref}->{err}

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -20,6 +20,20 @@ use Language::Bel::Core qw(
     SYMBOL_SYMBOL
     SYMBOL_T
 );
+use Language::Bel::Bytecode qw(
+    n
+    PARAM_IN
+    PARAM_LAST
+    PARAM_NEXT
+    PARAM_OUT
+    RETURN_REG
+    SET_PARAM_NEXT
+    SET_PRIM_ID_REG_SYM
+    SET_PRIM_TYPE_REG
+    SYM_NIL
+    SYM_T
+    SYM_PAIR
+);
 use Language::Bel::Pair::ByteFunc qw(
     make_bytefunc
 );
@@ -8817,7 +8831,30 @@ sub new {
         pair_set_cdr(
             pair_cdr(pair_cdr($self->{hash_ref}->{bcfn})),
             make_pair(
-                make_pair(make_symbol("no"), make_bytefunc(1, [])),
+                make_pair(make_symbol("no"), make_bytefunc(1, [
+                    PARAM_IN, n, n, n,
+                    SET_PARAM_NEXT, 0, n, n,
+                    PARAM_LAST, n, n, n,
+                    PARAM_OUT, n, n, n,
+                    SET_PRIM_ID_REG_SYM, 0, 0, SYM_NIL,
+                    RETURN_REG, 0, n, n,
+                ])),
+                pair_cdr(pair_cdr(pair_cdr($self->{hash_ref}->{bcfn}))),
+            ),
+        );
+        pair_set_cdr(
+            pair_cdr(pair_cdr($self->{hash_ref}->{bcfn})),
+            make_pair(
+                make_pair(make_symbol("atom"), make_bytefunc(1, [
+                    PARAM_IN, n, n, n,
+                    SET_PARAM_NEXT, 0, n, n,
+                    PARAM_LAST, n, n, n,
+                    PARAM_OUT, n, n, n,
+                    SET_PRIM_TYPE_REG, 0, 0, n,
+                    SET_PRIM_ID_REG_SYM, 0, 0, SYM_PAIR,
+                    SET_PRIM_ID_REG_SYM, 0, 0, SYM_NIL,
+                    RETURN_REG, 0, n, n,
+                ])),
                 pair_cdr(pair_cdr(pair_cdr($self->{hash_ref}->{bcfn}))),
             ),
         );

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -20,25 +20,11 @@ use Language::Bel::Core qw(
     SYMBOL_SYMBOL
     SYMBOL_T
 );
-use Language::Bel::Bytecode qw(
-    n
-    PARAM_IN
-    PARAM_LAST
-    PARAM_NEXT
-    PARAM_OUT
-    RETURN_REG
-    SET_PARAM_NEXT
-    SET_PRIM_ID_REG_SYM
-    SET_PRIM_TYPE_REG
-    SYM_NIL
-    SYM_T
-    SYM_PAIR
-);
-use Language::Bel::Pair::ByteFunc qw(
-    make_bytefunc
-);
 use Language::Bel::Pair::FastFunc qw(
     make_fastfunc
+);
+use Language::Bel::Globals::Bytecode qw(
+    bytefunc
 );
 use Language::Bel::Pair::CharsList qw(
     make_chars_list
@@ -8831,30 +8817,14 @@ sub new {
         pair_set_cdr(
             pair_cdr(pair_cdr($self->{hash_ref}->{bcfn})),
             make_pair(
-                make_pair(make_symbol("no"), make_bytefunc(1, [
-                    PARAM_IN, n, n, n,
-                    SET_PARAM_NEXT, 0, n, n,
-                    PARAM_LAST, n, n, n,
-                    PARAM_OUT, n, n, n,
-                    SET_PRIM_ID_REG_SYM, 0, 0, SYM_NIL,
-                    RETURN_REG, 0, n, n,
-                ])),
+                make_pair(make_symbol("no"), bytefunc("no")),
                 pair_cdr(pair_cdr(pair_cdr($self->{hash_ref}->{bcfn}))),
             ),
         );
         pair_set_cdr(
             pair_cdr(pair_cdr($self->{hash_ref}->{bcfn})),
             make_pair(
-                make_pair(make_symbol("atom"), make_bytefunc(1, [
-                    PARAM_IN, n, n, n,
-                    SET_PARAM_NEXT, 0, n, n,
-                    PARAM_LAST, n, n, n,
-                    PARAM_OUT, n, n, n,
-                    SET_PRIM_TYPE_REG, 0, 0, n,
-                    SET_PRIM_ID_REG_SYM, 0, 0, SYM_PAIR,
-                    SET_PRIM_ID_REG_SYM, 0, 0, SYM_NIL,
-                    RETURN_REG, 0, n, n,
-                ])),
+                make_pair(make_symbol("atom"), bytefunc("atom")),
                 pair_cdr(pair_cdr(pair_cdr($self->{hash_ref}->{bcfn}))),
             ),
         );

--- a/lib/Language/Bel/Globals/Bytecode.pm
+++ b/lib/Language/Bel/Globals/Bytecode.pm
@@ -1,0 +1,63 @@
+package Language::Bel::Globals::Bytecode;
+
+use 5.006;
+use strict;
+use warnings;
+
+use Language::Bel::Bytecode qw(
+    n
+    PARAM_IN
+    PARAM_LAST
+    PARAM_NEXT
+    PARAM_OUT
+    RETURN_REG
+    SET_PARAM_NEXT
+    SET_PRIM_ID_REG_SYM
+    SET_PRIM_TYPE_REG
+    SYM_NIL
+    SYM_T
+    SYM_PAIR
+);
+use Language::Bel::Pair::ByteFunc qw(
+    make_bytefunc
+);
+
+use Exporter 'import';
+
+my %bytefuncs = (
+    "no" => make_bytefunc(1, [
+        PARAM_IN, n, n, n,
+        SET_PARAM_NEXT, 0, n, n,
+        PARAM_LAST, n, n, n,
+        PARAM_OUT, n, n, n,
+        SET_PRIM_ID_REG_SYM, 0, 0, SYM_NIL,
+        RETURN_REG, 0, n, n,
+    ]),
+    "atom" => make_bytefunc(1, [
+        PARAM_IN, n, n, n,
+        SET_PARAM_NEXT, 0, n, n,
+        PARAM_LAST, n, n, n,
+        PARAM_OUT, n, n, n,
+        SET_PRIM_TYPE_REG, 0, 0, n,
+        SET_PRIM_ID_REG_SYM, 0, 0, SYM_PAIR,
+        SET_PRIM_ID_REG_SYM, 0, 0, SYM_NIL,
+        RETURN_REG, 0, n, n,
+    ]),
+);
+
+sub all_bytefuncs {
+    return keys(%bytefuncs);
+}
+
+sub bytefunc {
+    my ($name) = @_;
+
+    return $bytefuncs{$name};
+}
+
+our @EXPORT_OK = qw(
+    all_bytefuncs
+    bytefunc
+);
+
+1;

--- a/lib/Language/Bel/Globals/Bytecode.pm
+++ b/lib/Language/Bel/Globals/Bytecode.pm
@@ -8,14 +8,12 @@ use Language::Bel::Bytecode qw(
     n
     PARAM_IN
     PARAM_LAST
-    PARAM_NEXT
     PARAM_OUT
     RETURN_REG
     SET_PARAM_NEXT
     SET_PRIM_ID_REG_SYM
     SET_PRIM_TYPE_REG
     SYM_NIL
-    SYM_T
     SYM_PAIR
 );
 use Language::Bel::Pair::ByteFunc qw(

--- a/lib/Language/Bel/Globals/Generator.pm
+++ b/lib/Language/Bel/Globals/Generator.pm
@@ -100,6 +100,20 @@ use Language::Bel::Core qw(
     SYMBOL_SYMBOL
     SYMBOL_T
 );
+use Language::Bel::Bytecode qw(
+    n
+    PARAM_IN
+    PARAM_LAST
+    PARAM_NEXT
+    PARAM_OUT
+    RETURN_REG
+    SET_PARAM_NEXT
+    SET_PRIM_ID_REG_SYM
+    SET_PRIM_TYPE_REG
+    SYM_NIL
+    SYM_T
+    SYM_PAIR
+);
 use Language::Bel::Pair::ByteFunc qw(
     make_bytefunc
 );
@@ -458,17 +472,38 @@ HEADER
         print_global($global->{name}, $global->{expr}, $vmark, $smark);
     }
 
-    for my $name ("no") {
-        print <<"BCFN";
+    print <<'BCFN';
         pair_set_cdr(
-            pair_cdr(pair_cdr(\$self->{hash_ref}->{bcfn})),
+            pair_cdr(pair_cdr($self->{hash_ref}->{bcfn})),
             make_pair(
-                make_pair(make_symbol("$name"), make_bytefunc(1, [])),
-                pair_cdr(pair_cdr(pair_cdr(\$self->{hash_ref}->{bcfn}))),
+                make_pair(make_symbol("no"), make_bytefunc(1, [
+                    PARAM_IN, n, n, n,
+                    SET_PARAM_NEXT, 0, n, n,
+                    PARAM_LAST, n, n, n,
+                    PARAM_OUT, n, n, n,
+                    SET_PRIM_ID_REG_SYM, 0, 0, SYM_NIL,
+                    RETURN_REG, 0, n, n,
+                ])),
+                pair_cdr(pair_cdr(pair_cdr($self->{hash_ref}->{bcfn}))),
+            ),
+        );
+        pair_set_cdr(
+            pair_cdr(pair_cdr($self->{hash_ref}->{bcfn})),
+            make_pair(
+                make_pair(make_symbol("atom"), make_bytefunc(1, [
+                    PARAM_IN, n, n, n,
+                    SET_PARAM_NEXT, 0, n, n,
+                    PARAM_LAST, n, n, n,
+                    PARAM_OUT, n, n, n,
+                    SET_PRIM_TYPE_REG, 0, 0, n,
+                    SET_PRIM_ID_REG_SYM, 0, 0, SYM_PAIR,
+                    SET_PRIM_ID_REG_SYM, 0, 0, SYM_NIL,
+                    RETURN_REG, 0, n, n,
+                ])),
+                pair_cdr(pair_cdr(pair_cdr($self->{hash_ref}->{bcfn}))),
             ),
         );
 BCFN
-    }
 
     print <<'FOOTER';
     }

--- a/lib/Language/Bel/Globals/Generator.pm
+++ b/lib/Language/Bel/Globals/Generator.pm
@@ -91,6 +91,7 @@ use Language::Bel::Core qw(
     make_pair
     make_symbol
     pair_cdr
+    pair_set_cdr
     symbol_name
     SYMBOL_CHAR
     SYMBOL_NIL
@@ -98,6 +99,9 @@ use Language::Bel::Core qw(
     SYMBOL_QUOTE
     SYMBOL_SYMBOL
     SYMBOL_T
+);
+use Language::Bel::Pair::ByteFunc qw(
+    make_bytefunc
 );
 use Language::Bel::Pair::FastFunc qw(
     make_fastfunc
@@ -452,6 +456,18 @@ HEADER
         }
 
         print_global($global->{name}, $global->{expr}, $vmark, $smark);
+    }
+
+    for my $name ("no") {
+        print <<"BCFN";
+        pair_set_cdr(
+            pair_cdr(pair_cdr(\$self->{hash_ref}->{bcfn})),
+            make_pair(
+                make_pair(make_symbol("$name"), make_bytefunc(1, [])),
+                pair_cdr(pair_cdr(pair_cdr(\$self->{hash_ref}->{bcfn}))),
+            ),
+        );
+BCFN
     }
 
     print <<'FOOTER';

--- a/lib/Language/Bel/Globals/Generator.pm
+++ b/lib/Language/Bel/Globals/Generator.pm
@@ -27,6 +27,9 @@ use Language::Bel::Expander::Bquote qw(
 );
 use Language::Bel::Globals::Source;
 use Language::Bel::Globals::FastFuncs;
+use Language::Bel::Globals::Bytecode qw(
+    all_bytefuncs
+);
 use Language::Bel;
 
 use Exporter 'import';
@@ -100,25 +103,11 @@ use Language::Bel::Core qw(
     SYMBOL_SYMBOL
     SYMBOL_T
 );
-use Language::Bel::Bytecode qw(
-    n
-    PARAM_IN
-    PARAM_LAST
-    PARAM_NEXT
-    PARAM_OUT
-    RETURN_REG
-    SET_PARAM_NEXT
-    SET_PRIM_ID_REG_SYM
-    SET_PRIM_TYPE_REG
-    SYM_NIL
-    SYM_T
-    SYM_PAIR
-);
-use Language::Bel::Pair::ByteFunc qw(
-    make_bytefunc
-);
 use Language::Bel::Pair::FastFunc qw(
     make_fastfunc
+);
+use Language::Bel::Globals::Bytecode qw(
+    bytefunc
 );
 use Language::Bel::Pair::CharsList qw(
     make_chars_list
@@ -472,38 +461,17 @@ HEADER
         print_global($global->{name}, $global->{expr}, $vmark, $smark);
     }
 
-    print <<'BCFN';
+    for my $name (all_bytefuncs()) {
+        print <<"BCFN";
         pair_set_cdr(
-            pair_cdr(pair_cdr($self->{hash_ref}->{bcfn})),
+            pair_cdr(pair_cdr(\$self->{hash_ref}->{bcfn})),
             make_pair(
-                make_pair(make_symbol("no"), make_bytefunc(1, [
-                    PARAM_IN, n, n, n,
-                    SET_PARAM_NEXT, 0, n, n,
-                    PARAM_LAST, n, n, n,
-                    PARAM_OUT, n, n, n,
-                    SET_PRIM_ID_REG_SYM, 0, 0, SYM_NIL,
-                    RETURN_REG, 0, n, n,
-                ])),
-                pair_cdr(pair_cdr(pair_cdr($self->{hash_ref}->{bcfn}))),
-            ),
-        );
-        pair_set_cdr(
-            pair_cdr(pair_cdr($self->{hash_ref}->{bcfn})),
-            make_pair(
-                make_pair(make_symbol("atom"), make_bytefunc(1, [
-                    PARAM_IN, n, n, n,
-                    SET_PARAM_NEXT, 0, n, n,
-                    PARAM_LAST, n, n, n,
-                    PARAM_OUT, n, n, n,
-                    SET_PRIM_TYPE_REG, 0, 0, n,
-                    SET_PRIM_ID_REG_SYM, 0, 0, SYM_PAIR,
-                    SET_PRIM_ID_REG_SYM, 0, 0, SYM_NIL,
-                    RETURN_REG, 0, n, n,
-                ])),
-                pair_cdr(pair_cdr(pair_cdr($self->{hash_ref}->{bcfn}))),
+                make_pair(make_symbol("$name"), bytefunc("$name")),
+                pair_cdr(pair_cdr(pair_cdr(\$self->{hash_ref}->{bcfn}))),
             ),
         );
 BCFN
+    }
 
     print <<'FOOTER';
     }

--- a/lib/Language/Bel/Globals/Source.pm
+++ b/lib/Language/Bel/Globals/Source.pm
@@ -1808,3 +1808,6 @@ __DATA__
                     (err 'inst-nontable))))
 
 (def err args)
+
+(set bcfn (table))
+

--- a/lib/Language/Bel/Pair/ByteFunc.pm
+++ b/lib/Language/Bel/Pair/ByteFunc.pm
@@ -1,0 +1,73 @@
+package Language::Bel::Pair::ByteFunc;
+use base qw(Language::Bel::Pair);
+
+use 5.006;
+use strict;
+use warnings;
+
+use Language::Bel::Core qw(
+    is_nil
+    SYMBOL_NIL
+    SYMBOL_T
+);
+use Exporter 'import';
+
+sub new {
+    my ($class, $reg_count, $bytes) = @_;
+
+    my $obj = {
+        reg_count => $reg_count,
+        bytes => $bytes,
+    };
+    return bless($obj, $class);
+}
+
+sub car {
+    my ($self) = @_;
+
+    return SYMBOL_NIL;
+}
+
+sub cdr {
+    my ($self) = @_;
+
+    return SYMBOL_NIL;
+}
+
+sub xar {
+    my ($self, $car) = @_;
+
+    die "Attempted to modify a bytefunc\n";
+}
+
+sub xdr {
+    my ($self, $cdr) = @_;
+
+    die "Attempted to modify a bytefunc\n";
+}
+
+sub apply {
+    my ($self, $bel, @args) = @_;
+
+    my $first = @args > 0 ? $args[0] : SYMBOL_NIL;
+    return is_nil($first) ? SYMBOL_T : SYMBOL_NIL;
+}
+
+sub is_bytefunc {
+    my ($object) = @_;
+
+    return $object->isa(__PACKAGE__);
+}
+
+sub make_bytefunc {
+    my ($regcount, $bytes) = @_;
+
+    return __PACKAGE__->new($regcount, $bytes);
+}
+
+our @EXPORT_OK = qw(
+    is_bytefunc
+    make_bytefunc
+);
+
+1;

--- a/lib/Language/Bel/Pair/ByteFunc.pm
+++ b/lib/Language/Bel/Pair/ByteFunc.pm
@@ -17,15 +17,11 @@ use Language::Bel::Bytecode qw(
     n
     PARAM_IN
     PARAM_LAST
-    PARAM_NEXT
     PARAM_OUT
     RETURN_REG
     SET_PARAM_NEXT
     SET_PRIM_ID_REG_SYM
     SET_PRIM_TYPE_REG
-    SYM_NIL
-    SYM_T
-    SYM_PAIR
 );
 use Exporter 'import';
 

--- a/lib/Language/Bel/Pair/ByteFunc.pm
+++ b/lib/Language/Bel/Pair/ByteFunc.pm
@@ -124,6 +124,18 @@ sub apply {
     }
 }
 
+sub reg_count {
+    my ($self) = @_;
+
+    return $self->{reg_count};
+}
+
+sub bytes {
+    my ($self) = @_;
+
+    return $self->{bytes};
+}
+
 sub is_bytefunc {
     my ($object) = @_;
 

--- a/t/00-valid-bytecode.t
+++ b/t/00-valid-bytecode.t
@@ -1,0 +1,151 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings;
+use Test::More;
+
+use Language::Bel::Bytecode qw(
+    PARAM_IN
+    PARAM_LAST
+    PARAM_NEXT
+    PARAM_OUT
+    RETURN_REG
+    SET_PARAM_NEXT
+    SET_PRIM_ID_REG_SYM
+    SET_PRIM_TYPE_REG
+    SYM_NIL
+    SYM_T
+    SYM_PAIR
+);
+use Language::Bel::Globals::Bytecode qw(
+    bytefunc
+    all_bytefuncs
+);
+
+sub four_groups {
+    my ($array) = @_;
+
+    die "Length not divisible by 4"
+        unless scalar(@$array) % 4 == 0;
+
+    my @result;
+
+    my $index = 0;
+    while ($index < scalar(@$array)) {
+        push @result, [@$array[$index .. $index + 3]];
+        $index += 4;
+    }
+
+    return @result;
+}
+
+sub ops {
+    my ($bytefunc) = @_;
+
+    my $bytes = $bytefunc->bytes();
+    return four_groups($bytes);
+}
+
+sub in {
+    my ($element, @set) = @_;
+
+    return grep { $_ == $element } @set;
+}
+
+sub tests_per_bytefunc { 4 }
+
+sub registers_of {
+    my ($op) = @_;
+    my ($opcode, $operand1, $operand2, $operand3) = @$op;
+
+    if (in($opcode, PARAM_IN, PARAM_LAST, PARAM_OUT)) {
+        return ();
+    }
+    elsif (in($opcode, RETURN_REG, SET_PARAM_NEXT)) {
+        return ($operand1);
+    }
+    elsif (in($opcode, SET_PRIM_TYPE_REG)) {
+        return ($operand2, $operand1);
+    }
+    elsif (in($opcode, SET_PRIM_ID_REG_SYM)) {
+        return ($operand2, $operand1);
+    }
+    else {
+        die "Unknown opcode ", $opcode;
+    }
+}
+
+sub max {
+    my ($x, $y) = @_;
+
+    return $x > $y ? $x : $y;
+}
+
+my @PARAM_OPCODES = (
+    PARAM_IN,
+    PARAM_LAST,
+    PARAM_NEXT,
+    PARAM_OUT,
+    SET_PARAM_NEXT,
+);
+
+my @RETURN_OPCODES = (
+    RETURN_REG,
+);
+
+my @bytefuncs = all_bytefuncs();
+
+plan tests => scalar(@bytefuncs) * tests_per_bytefunc();
+
+for my $name (@bytefuncs) {
+    my $bytefunc = bytefunc($name);
+
+    my $seen_non_param_op = 0;
+    my $param_op_after_non_param_op = 0;
+
+    my $max_register_index = -1;
+    my $register_count = $bytefunc->reg_count();
+
+    my $next_register_expected = 0;
+    my $registers_introduced_in_sequence = 1;
+
+    my $last_instruction_is_return = 0;
+
+    for my $op (ops($bytefunc)) {
+        my ($opcode, $operand1, $operand2, $operand3) = @$op;
+
+        if (!in($opcode, @PARAM_OPCODES)) {
+            $seen_non_param_op = 1;
+        }
+
+        if ($seen_non_param_op && in($opcode, @PARAM_OPCODES)) {
+            $param_op_after_non_param_op = 1;
+        }
+
+        for my $register (registers_of($op)) {
+            $max_register_index = max($register, $max_register_index);
+
+            if ($register == $next_register_expected) {
+                $next_register_expected += 1;
+            }
+            elsif ($register > $next_register_expected) {
+                $registers_introduced_in_sequence = 0;
+            }
+        }
+
+        $last_instruction_is_return = in($opcode, @RETURN_OPCODES);
+    }
+
+    ok !$param_op_after_non_param_op,
+        "$name - no param-handling op after non-param-handling op";
+
+    is $max_register_index + 1, $register_count,
+        "$name - the register index is always one below the register count";
+
+    ok $registers_introduced_in_sequence,
+        "$name - registers are introduced in sequence 0..*";
+
+    ok $last_instruction_is_return,
+        "$name - the last instruction is RETURN";
+}
+

--- a/t/bcfn-atom.t
+++ b/t/bcfn-atom.t
@@ -1,0 +1,20 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings;
+use Language::Bel::Test::DSL;
+
+__DATA__
+
+> (bcfn!atom \a)
+t
+
+> (bcfn!atom nil)
+t
+
+> (bcfn!atom 'a)
+t
+
+> (bcfn!atom '(a))
+nil
+

--- a/t/bcfn-no.t
+++ b/t/bcfn-no.t
@@ -1,0 +1,41 @@
+#!perl -T
+use 5.006;
+use strict;
+use warnings;
+use Language::Bel::Test::DSL;
+
+__DATA__
+
+> (bcfn!no nil)
+t
+
+> (bcfn!no 'nil)
+t
+
+> (bcfn!no '())
+t
+
+> (bcfn!no t)
+nil
+
+> (bcfn!no 'x)
+nil
+
+> (bcfn!no \c)
+nil
+
+> (bcfn!no '(nil))
+nil
+
+> (bcfn!no '(a . b))
+nil
+
+> (bcfn!no no)
+nil
+
+> (bcfn!no bcfn!no)
+nil
+
+> (bcfn!no (bcfn!no bcfn!no))
+t
+


### PR DESCRIPTION
Besides a few easily fixable consistency errors, I think this one can be merged. No need to drag our feet getting these changes incorporated.

Some likely next steps:

- [x] Write a verifier that checks that the bytecode in `Globals/Bytecode.pm` is well-formed
- [ ] Write a small compiler pipeline that can generate that bytecode
- [ ] Write a "decompiler" that can generate Perl fastfuncs from the bytecode
- [ ] Implement more bytefuncs
- [ ] Expand into supporting function calls and resumable bytefuncs