### PR TITLE
Make sure bytefuncs are always returned in insertion order

### DIFF
--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -23,7 +23,7 @@ use Language::Bel::Core qw(
 use Language::Bel::Pair::FastFunc qw(
     make_fastfunc
 );
-use Language::Bel::Globals::Bytecode qw(
+use Language::Bel::Globals::ByteFuncs qw(
     bytefunc
 );
 use Language::Bel::Pair::CharsList qw(

--- a/lib/Language/Bel/Globals/ByteFuncs.pm
+++ b/lib/Language/Bel/Globals/ByteFuncs.pm
@@ -1,4 +1,4 @@
-package Language::Bel::Globals::Bytecode;
+package Language::Bel::Globals::ByteFuncs;
 
 use 5.006;
 use strict;

--- a/lib/Language/Bel/Globals/Bytecode.pm
+++ b/lib/Language/Bel/Globals/Bytecode.pm
@@ -22,29 +22,39 @@ use Language::Bel::Pair::ByteFunc qw(
 
 use Exporter 'import';
 
-my %bytefuncs = (
-    "no" => make_bytefunc(1, [
-        PARAM_IN, n, n, n,
-        SET_PARAM_NEXT, 0, n, n,
-        PARAM_LAST, n, n, n,
-        PARAM_OUT, n, n, n,
-        SET_PRIM_ID_REG_SYM, 0, 0, SYM_NIL,
-        RETURN_REG, 0, n, n,
-    ]),
-    "atom" => make_bytefunc(1, [
-        PARAM_IN, n, n, n,
-        SET_PARAM_NEXT, 0, n, n,
-        PARAM_LAST, n, n, n,
-        PARAM_OUT, n, n, n,
-        SET_PRIM_TYPE_REG, 0, 0, n,
-        SET_PRIM_ID_REG_SYM, 0, 0, SYM_PAIR,
-        SET_PRIM_ID_REG_SYM, 0, 0, SYM_NIL,
-        RETURN_REG, 0, n, n,
-    ]),
+my @all_bytefuncs;
+my %bytefuncs;
+
+sub add_bytefunc {
+    my ($name, $reg_count, @bytes) = @_;
+
+    my $bytefunc = make_bytefunc($reg_count, [@bytes]);
+    push @all_bytefuncs, $name;
+    $bytefuncs{$name} = $bytefunc;
+}
+
+add_bytefunc("no", 1,
+    PARAM_IN, n, n, n,
+    SET_PARAM_NEXT, 0, n, n,
+    PARAM_LAST, n, n, n,
+    PARAM_OUT, n, n, n,
+    SET_PRIM_ID_REG_SYM, 0, 0, SYM_NIL,
+    RETURN_REG, 0, n, n,
+);
+
+add_bytefunc("atom", 1,
+    PARAM_IN, n, n, n,
+    SET_PARAM_NEXT, 0, n, n,
+    PARAM_LAST, n, n, n,
+    PARAM_OUT, n, n, n,
+    SET_PRIM_TYPE_REG, 0, 0, n,
+    SET_PRIM_ID_REG_SYM, 0, 0, SYM_PAIR,
+    SET_PRIM_ID_REG_SYM, 0, 0, SYM_NIL,
+    RETURN_REG, 0, n, n,
 );
 
 sub all_bytefuncs {
-    return keys(%bytefuncs);
+    return @all_bytefuncs;
 }
 
 sub bytefunc {

--- a/lib/Language/Bel/Globals/Generator.pm
+++ b/lib/Language/Bel/Globals/Generator.pm
@@ -27,7 +27,7 @@ use Language::Bel::Expander::Bquote qw(
 );
 use Language::Bel::Globals::Source;
 use Language::Bel::Globals::FastFuncs;
-use Language::Bel::Globals::Bytecode qw(
+use Language::Bel::Globals::ByteFuncs qw(
     all_bytefuncs
 );
 use Language::Bel;
@@ -106,7 +106,7 @@ use Language::Bel::Core qw(
 use Language::Bel::Pair::FastFunc qw(
     make_fastfunc
 );
-use Language::Bel::Globals::Bytecode qw(
+use Language::Bel::Globals::ByteFuncs qw(
     bytefunc
 );
 use Language::Bel::Pair::CharsList qw(

--- a/t/00-valid-bytecode.t
+++ b/t/00-valid-bytecode.t
@@ -17,7 +17,7 @@ use Language::Bel::Bytecode qw(
     SYM_T
     SYM_PAIR
 );
-use Language::Bel::Globals::Bytecode qw(
+use Language::Bel::Globals::ByteFuncs qw(
     bytefunc
     all_bytefuncs
 );


### PR DESCRIPTION
This should take care of the recent spurious test failure.