### PR TITLE
Make a few preparatory changes before adding the bytecode compiler

### DIFF
--- a/lib/Language/Bel/Bytecode.pm
+++ b/lib/Language/Bel/Bytecode.pm
@@ -17,9 +17,27 @@ sub SET_PRIM_TYPE_REG { 0x11 }
 
 sub RETURN_REG { 0xF0 }
 
-sub SYM_NIL { 0 }
-sub SYM_T { 1 }
-sub SYM_PAIR { 2 }
+my @registered_symbols = (
+    "nil",
+    "t",
+    "pair",
+);
+
+my %index_of;
+my $index = 0;
+for my $name (@registered_symbols) {
+    $index_of{$name} = $index;
+    ++$index;
+}
+
+sub SYMBOL {
+    my ($name) = @_;
+
+    die "Unknown symbo `$name`"
+        unless defined $index_of{$name};
+
+    return $index_of{$name};
+}
 
 sub n { 0 }
 
@@ -33,9 +51,7 @@ our @EXPORT_OK = qw(
     SET_PARAM_NEXT
     SET_PRIM_ID_REG_SYM
     SET_PRIM_TYPE_REG
-    SYM_NIL
-    SYM_T
-    SYM_PAIR
+    SYMBOL
 );
 
 1;

--- a/lib/Language/Bel/Globals/ByteFuncs.pm
+++ b/lib/Language/Bel/Globals/ByteFuncs.pm
@@ -13,8 +13,7 @@ use Language::Bel::Bytecode qw(
     SET_PARAM_NEXT
     SET_PRIM_ID_REG_SYM
     SET_PRIM_TYPE_REG
-    SYM_NIL
-    SYM_PAIR
+    SYMBOL
 );
 use Language::Bel::Pair::ByteFunc qw(
     make_bytefunc
@@ -38,7 +37,7 @@ add_bytefunc("no", 1,
     SET_PARAM_NEXT, 0, n, n,
     PARAM_LAST, n, n, n,
     PARAM_OUT, n, n, n,
-    SET_PRIM_ID_REG_SYM, 0, 0, SYM_NIL,
+    SET_PRIM_ID_REG_SYM, 0, 0, SYMBOL("nil"),
     RETURN_REG, 0, n, n,
 );
 
@@ -48,8 +47,8 @@ add_bytefunc("atom", 1,
     PARAM_LAST, n, n, n,
     PARAM_OUT, n, n, n,
     SET_PRIM_TYPE_REG, 0, 0, n,
-    SET_PRIM_ID_REG_SYM, 0, 0, SYM_PAIR,
-    SET_PRIM_ID_REG_SYM, 0, 0, SYM_NIL,
+    SET_PRIM_ID_REG_SYM, 0, 0, SYMBOL("pair"),
+    SET_PRIM_ID_REG_SYM, 0, 0, SYMBOL("nil"),
     RETURN_REG, 0, n, n,
 );
 

--- a/t/00-valid-bytecode.t
+++ b/t/00-valid-bytecode.t
@@ -13,9 +13,6 @@ use Language::Bel::Bytecode qw(
     SET_PARAM_NEXT
     SET_PRIM_ID_REG_SYM
     SET_PRIM_TYPE_REG
-    SYM_NIL
-    SYM_T
-    SYM_PAIR
 );
 use Language::Bel::Globals::ByteFuncs qw(
     bytefunc


### PR DESCRIPTION
This consists of replacing named SYM_* subroutines with a single SYMBOL subroutine.

The compiler branch is turning long-running, and I'd prefer to break off this change and have it integrated ASAP.