### PR TITLE
Move 'deindent' calls into Language::Bel::Test

### DIFF
--- a/lib/Language/Bel/Test.pm
+++ b/lib/Language/Bel/Test.pm
@@ -162,18 +162,19 @@ sub deindent {
 
 sub test_compilation {
     my ($source, $target) = @_;
+
+    $source = deindent($source);
     $source =~ /^\(def (\S+)/
         or die "Couldn't parse out the name from '$source'";
     my $name = $1;
 
     is belify_bytefunc(compile($source)),
-        $target,
+        deindent($target),
         "compilation of `$name`";
 }
 
 our @EXPORT = qw(
     bel_todo
-    deindent
     for_each_line_in_file
     output_of_eval_file
     slurp_file

--- a/t/compile-empty.t
+++ b/t/compile-empty.t
@@ -4,17 +4,16 @@ use strict;
 use warnings;
 use Test::More;
 use Language::Bel::Test qw(
-    deindent
     test_compilation
 );
 
 plan tests => 1;
 
-my $source = deindent("
+my $source = "
     (def empty (x))
-");
+";
 
-my $target = deindent("
+my $target = "
     (bytefunc 1
       (param!in)
       (param!next)
@@ -22,7 +21,7 @@ my $target = deindent("
       (param!out)
       (%0 := 'nil)
       (return %0))
-");
+";
 
 test_compilation($source, $target);
 

--- a/t/compile-fn-atom.t
+++ b/t/compile-fn-atom.t
@@ -4,18 +4,17 @@ use strict;
 use warnings;
 use Test::More;
 use Language::Bel::Test qw(
-    deindent
     test_compilation
 );
 
 plan tests => 1;
 
-my $source = deindent("
+my $source = "
     (def atom (x)
       (no (id (type x) 'pair)))
-");
+";
 
-my $target = deindent("
+my $target = "
     (bytefunc 1
       (param!in)
       (%0 := param!next)
@@ -25,7 +24,7 @@ my $target = deindent("
       (%0 := prim!id %0 'pair)
       (%0 := prim!id %0 'nil)
       (return %0))
-");
+";
 
 test_compilation($source, $target);
 

--- a/t/compile-fn-no.t
+++ b/t/compile-fn-no.t
@@ -4,18 +4,17 @@ use strict;
 use warnings;
 use Test::More;
 use Language::Bel::Test qw(
-    deindent
     test_compilation
 );
 
 plan tests => 1;
 
-my $source = deindent("
+my $source = "
     (def no (x)
       (id x nil))
-");
+";
 
-my $target = deindent("
+my $target = "
     (bytefunc 1
       (param!in)
       (%0 := param!next)
@@ -23,7 +22,7 @@ my $target = deindent("
       (param!out)
       (%0 := prim!id %0 'nil)
       (return %0))
-");
+";
 
 test_compilation($source, $target);
 


### PR DESCRIPTION
<del>Needs to be rebased on a merged #362.</del> Rebased.

Just a small fix/improvement.