### PR TITLE
Add 'array' fastfunc

### DIFF
--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -107,6 +107,7 @@ use Language::Bel::Globals::FastFuncs qw(
     fastfunc__dedup
     fastfunc__randlen
     fastfunc__rand
+    fastfunc__array
     fastfunc__err
 );
 
@@ -8587,7 +8588,7 @@ sub new {
             make_pair(make_symbol("args"), SYMBOL_NIL))), SYMBOL_NIL)),
             SYMBOL_NIL))))), \&fastfunc__prs));
 
-        $self->add_global("array", make_pair(make_symbol("lit"),
+        $self->add_global("array", make_fastfunc(make_pair(make_symbol("lit"),
             make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
             make_pair(make_pair(make_symbol("dims"),
             make_pair(make_pair(make_symbol("o"), make_pair(make_symbol("default"),
@@ -8605,7 +8606,7 @@ sub new {
             make_pair(make_pair(make_symbol("cdr"), make_pair(make_symbol("dims"),
             SYMBOL_NIL)), make_pair(make_symbol("default"), SYMBOL_NIL))),
             SYMBOL_NIL))), make_pair(SYMBOL_NIL, SYMBOL_NIL))), SYMBOL_NIL))),
-            SYMBOL_NIL))), SYMBOL_NIL)))), SYMBOL_NIL))))));
+            SYMBOL_NIL))), SYMBOL_NIL)))), SYMBOL_NIL))))), \&fastfunc__array));
 
         $self->add_global("aref", make_pair(make_symbol("lit"),
             make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,

--- a/lib/Language/Bel/Globals/FastFuncs.pm
+++ b/lib/Language/Bel/Globals/FastFuncs.pm
@@ -3644,6 +3644,39 @@ sub fastfunc__rand {
     );
 }
 
+sub fastfunc__array {
+    my ($bel, $dims, $default) = @_;
+
+    if (!defined($default)) {
+        $default = SYMBOL_NIL;
+    }
+
+    if (is_nil($dims)) {
+        return $default;
+    }
+
+    my $car_dims = $bel->car($dims);
+    my $n = maybe_get_int($bel, $car_dims);
+    die "mistype\n"
+        unless defined($n);
+    my $result = SYMBOL_NIL;
+    for (1 .. $n) {
+        $result = make_pair(
+            fastfunc__array($bel, $bel->cdr($dims), $default),
+            $result,
+        );
+    }
+    $result = make_pair(
+        make_symbol("lit"),
+        make_pair(
+            make_symbol("arr"),
+            $result,
+        ),
+    );
+
+    return $result;
+}
+
 sub fastfunc__err {
     my ($bel, $msg) = @_;
 
@@ -3727,6 +3760,7 @@ our @EXPORT_OK = qw(
     fastfunc__dedup
     fastfunc__randlen
     fastfunc__rand
+    fastfunc__array
     fastfunc__err
 );
 

--- a/lib/Language/Bel/Globals/FastFuncs/Source.pm
+++ b/lib/Language/Bel/Globals/FastFuncs/Source.pm
@@ -3645,6 +3645,39 @@ sub fastfunc__rand {
     );
 }
 
+sub fastfunc__array {
+    my ($bel, $dims, $default) = @_;
+
+    if (!defined($default)) {
+        $default = SYMBOL_NIL;
+    }
+
+    if (is_nil($dims)) {
+        return $default;
+    }
+
+    my $car_dims = $bel->car($dims);
+    my $n = maybe_get_int($bel, $car_dims);
+    die "mistype\n"
+        unless defined($n);
+    my $result = SYMBOL_NIL;
+    for (1 .. $n) {
+        $result = make_pair(
+            fastfunc__array($bel, $bel->cdr($dims), $default),
+            $result,
+        );
+    }
+    $result = make_pair(
+        make_symbol("lit"),
+        make_pair(
+            make_symbol("arr"),
+            $result,
+        ),
+    );
+
+    return $result;
+}
+
 sub fastfunc__err {
     my ($bel, $msg) = @_;
 
@@ -3728,6 +3761,7 @@ our @EXPORT_OK = qw(
     fastfunc__dedup
     fastfunc__randlen
     fastfunc__rand
+    fastfunc__array
     fastfunc__err
 );
 


### PR DESCRIPTION
A bit of a downpayment on #200; `t/fn-array.t` was the slowest function by far among the original 10.