### PR TITLE
Introduce an 'async call' mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ After downloading Bel, you can run it like this:
 
 ```sh
 $ perl -Ilib bin/bel
-Language::Bel 0.58 -- darwin.
+Language::Bel 0.59 -- darwin.
 >
 > ;; loops
 > (set n (len (apply append prims)))

--- a/lib/Language/Bel.pm
+++ b/lib/Language/Bel.pm
@@ -52,11 +52,11 @@ Language::Bel - An interpreter for Paul Graham's language Bel
 
 =head1 VERSION
 
-Version 0.58
+Version 0.59
 
 =cut
 
-our $VERSION = '0.58';
+our $VERSION = '0.59';
 
 =head1 SYNOPSIS
 

--- a/lib/Language/Bel/AsyncCall.pm
+++ b/lib/Language/Bel/AsyncCall.pm
@@ -1,0 +1,55 @@
+package Language::Bel::AsyncCall;
+
+use 5.006;
+use strict;
+use warnings;
+
+use Exporter 'import';
+
+sub new {
+    my ($class, $fn, $args_ref, $cont_sub) = @_;
+
+    my $obj = {
+        fn => $fn,
+        args_ref => $args_ref,
+        cont_sub => $cont_sub,
+    };
+    return bless($obj, $class);
+}
+
+sub fn {
+    my ($self) = @_;
+
+    return $self->{fn};
+}
+
+sub args_ref {
+    my ($self) = @_;
+
+    return $self->{args_ref};
+}
+
+sub invoke_cont {
+    my ($self, $value) = @_;
+
+    return $self->{cont_sub}->($value);
+}
+
+sub is_async_call {
+    my ($value) = @_;
+
+    return $value->isa(__PACKAGE__);
+}
+
+sub make_async_call {
+    my ($fn, $args_ref, $cont_sub) = @_;
+
+    return __PACKAGE__->new($fn, $args_ref, $cont_sub);
+}
+
+our @EXPORT_OK = qw(
+    is_async_call
+    make_async_call
+);
+
+1;


### PR DESCRIPTION
This is what the fastfuncs need to be able to make calls and get back control afterwards, without technically making a call from within themselves (but instead asking the interpreter to do so).

Conceptually, the new `Language::Bel::AsyncCall` class corresponds to two FutFuncs being pushed onto the evaluation stack; one to call the desired function, and the other to consume the result and do whatever it was the fastfunc wanted to do next... like a continuation.

It's a little bit different to code in this style. In summary: certain backward jumps (like usually expressed with `while` and
the like) and certain forward jumps (like usually expressed with `last`, or simply falling out of a loop) are now instead expressed using calls of this style: `$loop->($c1, $c2, ...)`.

Most values do not in fact need to be passed through the `$loop` function as parameters; they are naturally closed over by normal Perl mechanisms. Usually a single counter is enough, if that.

The reason regular jumps (and their "structured code" equivalents) are not possible to use in these situations is that an async call establishes a function boundary between the source and destination points of the jump. There's typically no reason to worry about the stack being used up, since at each async call, the interpreter resets the stack. In the cases where there _isn't_ an async call, a simple `while` loop is preferable.

This whole situation is reminiscent of Node.js and callback functions. I can't recall using even them in such a "rich" way,
though. It goes without saying that (just like in Node.js), it would be preferable to write the code in a way that avoided all
this (as is possible in JavaScript nowadays with `async` and `await`). We could resurrect the FastFunc source generator for
this purpose, but... it would need to be improved so that it could handle this case in a robust way. CPS transform, something
something.

Note that in Perl, the following style is necessary:

```perl
my $loop;
$loop = sub {
    # ...
    $loop->();
};
```

That is, initializing `$loop` on a separate line using an assignment, not using the initializer syntax on variable
declarations. This is due to the fact that in Perl, a new variable is not considered fully declared until after its `my`
statement, and we need to refer to `$loop` from within its function.