### PR TITLE
Implement 'deq' fastfunc

### DIFF
--- a/lib/Language/Bel.pm
+++ b/lib/Language/Bel.pm
@@ -144,10 +144,16 @@ sub cdr {
     $self->{primitives}->prim_cdr($pair);
 }
 
-sub xdr {
-    my ($self, $pair, $d) = @_;
+sub xar {
+    my ($self, $pair, $new_a) = @_;
 
-    $self->{primitives}->prim_xdr($pair, $d);
+    $self->{primitives}->prim_xar($pair, $new_a);
+}
+
+sub xdr {
+    my ($self, $pair, $new_d) = @_;
+
+    $self->{primitives}->prim_xdr($pair, $new_d);
 }
 
 =head2 read_eval_print

--- a/lib/Language/Bel/Globals.pm
+++ b/lib/Language/Bel/Globals.pm
@@ -111,6 +111,7 @@ use Language::Bel::Globals::FastFuncs qw(
     fastfunc__int
     fastfunc__pint
     fastfunc__charn
+    fastfunc__deq
     fastfunc__prn
     fastfunc__pr
     fastfunc__prs
@@ -4270,7 +4271,7 @@ sub new {
             SYMBOL_NIL)), make_pair(make_symbol("q"), SYMBOL_NIL))),
             SYMBOL_NIL))))));
 
-        $self->add_global("deq", make_pair(make_symbol("lit"),
+        $self->add_global("deq", make_fastfunc(make_pair(make_symbol("lit"),
             make_pair(make_symbol("clo"), make_pair(SYMBOL_NIL,
             make_pair(make_pair(make_symbol("q"), SYMBOL_NIL),
             make_pair(make_pair(make_symbol("atomic"),
@@ -4281,7 +4282,7 @@ sub new {
             make_pair(make_symbol("q"), make_pair(make_pair(make_symbol("cdr"),
             make_pair(make_pair(make_symbol("car"), make_pair(make_symbol("q"),
             SYMBOL_NIL)), SYMBOL_NIL)), SYMBOL_NIL))), SYMBOL_NIL))), SYMBOL_NIL)),
-            SYMBOL_NIL))))));
+            SYMBOL_NIL))))), \&fastfunc__deq));
 
         $self->add_global("set", make_pair(make_symbol("lit"),
             make_pair(make_symbol("mac"), make_pair(make_pair(make_symbol("lit"),

--- a/lib/Language/Bel/Globals/FastFuncs.pm
+++ b/lib/Language/Bel/Globals/FastFuncs.pm
@@ -4337,6 +4337,14 @@ sub fastfunc__charn {
     );
 }
 
+sub fastfunc__deq {
+    my ($bel, $q) = @_;
+
+    my $do1 = $bel->car($bel->car($q));
+    $bel->xar($q, $bel->cdr($bel->car($q)));
+    return $do1;
+}
+
 sub fastfunc__prn {
     my ($bel, @args) = @_;
 
@@ -4707,6 +4715,7 @@ our @EXPORT_OK = qw(
     fastfunc__int
     fastfunc__pint
     fastfunc__charn
+    fastfunc__deq
     fastfunc__prn
     fastfunc__pr
     fastfunc__prs


### PR DESCRIPTION
Implementing the fastfunc itself did shave some time off the t/fn-read.t test, so there's that. A further idea of making the fast string object "stateful" (keeping a position which could be unsafely updated by the fastfunc) did not make a significant difference.